### PR TITLE
chore(license): unify to CC BY-NC-SA 4.0 via central license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 理論計算機科学教科書
 
 [![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-deployed-green)](https://itdojp.github.io/theoretical-computer-science-textbook/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md)
 [![Jekyll](https://img.shields.io/badge/Jekyll-4.3-red)](https://jekyllrb.com/)
 
 数学的基礎から始まり、計算理論、アルゴリズム、複雑性理論、そして最新の研究トピックまでを包括的にカバーする理論計算機科学の教科書。大学生、大学院生、研究者向けの体系的学習リソース。
@@ -168,7 +168,12 @@ tests/                     # テストファイル
 
 ## 📄 ライセンス
 
-[MIT License](LICENSE) - 教育・研究目的での自由な利用を許可
+本書は ITDO Inc. の統一ライセンスに従います。
+
+- ライセンス本文: https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md
+- クリエイティブ・コモンズ: CC BY-NC-SA 4.0（非営利・継承・表示）
+
+商用利用をご希望の場合は、商用ライセンス契約が必要です（詳細は上記ライセンスを参照）。
 
 ## 👥 著者・コントリビューター
 

--- a/book-config.json
+++ b/book-config.json
@@ -4,7 +4,7 @@
   "author": "ITDO Inc.（株式会社アイティードゥ）",
   "version": "1.0.0",
   "language": "ja",
-  "license": "MIT",
+  "license": "CC-BY-NC-SA-4.0",
   "repository": {
     "url": "https://github.com/itdojp/theoretical-computer-science-textbook.git",
     "branch": "main"

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
     "ja"
   ],
   "author": "ITDO Inc.",
-  "license": "MIT",
+  "license": "CC-BY-NC-SA-4.0",
   "devDependencies": {
     "markdownlint-cli": "^0.37.0",
     "markdown-link-check": "^3.11.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "理論計算機科学教本 - コンピュータサイエンス基礎理論",
   "author": "ITDO Inc.（株式会社アイティードゥ）",
-  "license": "MIT",
+  "license": "CC-BY-NC-SA-4.0",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
This PR aligns the book\u2019s licensing with the central policy per ISSUE #25.\n\nSummary\n- Switch license references from MIT to **CC BY-NC-SA 4.0** following the central license document.\n- Point badges and README to the canonical license URL.\n\nChanges\n- README: replace MIT badge with CC BY-NC-SA 4.0 badge; rewrite the License section to link to the central license\n- package.json: "license": CC-BY-NC-SA-4.0\n- docs/package.json: "license": CC-BY-NC-SA-4.0\n- book-config.json: "license": CC-BY-NC-SA-4.0\n\nNotes\n- Existing LICENSE / LICENSE.md already refer to the central license and CC BY-NC-SA 4.0, so no changes there.\n- package-lock.json contains dependency licenses and is intentionally left untouched.\n\nAcceptance Criteria\n- README shows CC BY-NC-SA 4.0 badge linking to https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md\n- package.json, docs/package.json, book-config.json show CC-BY-NC-SA-4.0\n- CI passes\n\nCloses #25