### PR TITLE
figs(batch2): ch3 Thompson steps + ch8 Dijkstra step trace

### DIFF
--- a/docs/assets/images/diagrams/ch3_regex_to_nfa_thompson_steps.svg
+++ b/docs/assets/images/diagrams/ch3_regex_to_nfa_thompson_steps.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 360" role="img" aria-labelledby="title desc">
+  <title id="title">Thompson 構成法：正規表現から ε-NFA への段階的変換</title>
+  <desc id="desc">リテラル、連結、和 (+)、クリーネ閉包 (*) の各構成規則を小さなNFAブロックで示し、最終的に複合正規表現を合成する手順の概観図。</desc>
+  <defs>
+    <style>
+      .label { fill: #111; font-family: Inter, Helvetica, Arial, sans-serif; font-size: 12px; }
+      .box { fill: #f8f9fa; stroke: #adb5bd; stroke-width: 1.5; }
+      .state { fill: #fff; stroke: #495057; stroke-width: 1.5; }
+      .accept { fill: #e6fcf5; }
+      .arrow { stroke: #212529; stroke-width: 1.5; marker-end: url(#m); }
+      .earrow { stroke: #15aabf; stroke-dasharray: 4 3; stroke-width: 1.5; marker-end: url(#m2); }
+    </style>
+    <marker id="m" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#212529" />
+    </marker>
+    <marker id="m2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#15aabf" />
+    </marker>
+  </defs>
+
+  <!-- Literal -->
+  <g transform="translate(20,20)">
+    <rect class="box" x="0" y="0" width="200" height="120" rx="8"/>
+    <text class="label" x="8" y="16">リテラル `a`</text>
+    <circle class="state" cx="40" cy="70" r="14"/>
+    <circle class="state accept" cx="160" cy="70" r="14"/>
+    <line class="arrow" x1="54" y1="70" x2="146" y2="70"/>
+    <text class="label" x="96" y="62" text-anchor="middle">a</text>
+  </g>
+
+  <!-- Concatenation -->
+  <g transform="translate(260,20)">
+    <rect class="box" x="0" y="0" width="200" height="120" rx="8"/>
+    <text class="label" x="8" y="16">連結 `ab`</text>
+    <circle class="state" cx="30" cy="70" r="14"/>
+    <circle class="state" cx="100" cy="70" r="14"/>
+    <circle class="state accept" cx="170" cy="70" r="14"/>
+    <line class="arrow" x1="44" y1="70" x2="86" y2="70"/>
+    <text class="label" x="65" y="62" text-anchor="middle">a</text>
+    <line class="arrow" x1="114" y1="70" x2="156" y2="70"/>
+    <text class="label" x="135" y="62" text-anchor="middle">b</text>
+  </g>
+
+  <!-- Union -->
+  <g transform="translate(500,20)">
+    <rect class="box" x="0" y="0" width="200" height="120" rx="8"/>
+    <text class="label" x="8" y="16">和 `a+b`</text>
+    <circle class="state" cx="30" cy="70" r="14"/>
+    <circle class="state accept" cx="170" cy="40" r="14"/>
+    <circle class="state accept" cx="170" cy="100" r="14"/>
+    <line class="earrow" x1="44" y1="70" x2="156" y2="40"/>
+    <text class="label" x="102" y="52" text-anchor="middle">a</text>
+    <line class="earrow" x1="44" y1="70" x2="156" y2="100"/>
+    <text class="label" x="102" y="94" text-anchor="middle">b</text>
+  </g>
+
+  <!-- Kleene star -->
+  <g transform="translate(20,200)">
+    <rect class="box" x="0" y="0" width="320" height="120" rx="8"/>
+    <text class="label" x="8" y="16">クリーネ閉包 `a*`（ε遷移と自己ループ）</text>
+    <circle class="state" cx="40" cy="70" r="14"/>
+    <circle class="state accept" cx="280" cy="70" r="14"/>
+    <line class="earrow" x1="54" y1="70" x2="266" y2="70"/>
+    <text class="label" x="160" y="62" text-anchor="middle">ε</text>
+    <circle class="state" cx="160" cy="70" r="14"/>
+    <line class="arrow" x1="174" y1="70" x2="220" y2="70"/>
+    <text class="label" x="197" y="62" text-anchor="middle">a</text>
+    <line class="earrow" x1="220" y1="64" x2="172" y2="64"/>
+    <text class="label" x="196" y="52" text-anchor="middle">ε</text>
+    <line class="earrow" x1="154" y1="70" x2="54" y2="70"/>
+    <text class="label" x="100" y="62" text-anchor="middle">ε</text>
+    <line class="earrow" x1="266" y1="70" x2="174" y2="70"/>
+    <text class="label" x="222" y="88" text-anchor="middle">ε</text>
+  </g>
+
+  <!-- Compose note -->
+  <text class="label" x="360" y="340" text-anchor="middle">各ブロックを合成して複合正規表現の ε-NFA を構成</text>
+</svg>
+

--- a/docs/assets/images/diagrams/ch8_dijkstra_step_trace.svg
+++ b/docs/assets/images/diagrams/ch8_dijkstra_step_trace.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 360" role="img" aria-labelledby="title desc">
+  <title id="title">Dijkstra 法の逐次確定の例（小規模グラフ）</title>
+  <desc id="desc">始点sから他頂点への最短距離を段階的に確定する様子。確定集合Sとフロンティアの更新を模式的に示す。</desc>
+  <defs>
+    <style>
+      .label { fill: #111; font-family: Inter, Helvetica, Arial, sans-serif; font-size: 12px; }
+      .node { fill: #fff; stroke: #495057; stroke-width: 2; }
+      .fixed { fill: #e6fcf5; }
+      .frontier { fill: #fff3bf; }
+      .edge { stroke: #495057; stroke-width: 1.5; }
+      .best { stroke: #228be6; stroke-width: 2.5; }
+    </style>
+  </defs>
+
+  <!-- Panel 1 -->
+  <g transform="translate(20,20)">
+    <text class="label" x="0" y="-4">Step 1: s を確定（距離 0）</text>
+    <line class="edge" x1="60" y1="60" x2="180" y2="40"/>
+    <line class="edge" x1="60" y1="60" x2="180" y2="100"/>
+    <line class="edge" x1="180" y1="40" x2="300" y2="60"/>
+    <line class="edge" x1="180" y1="100" x2="300" y2="60"/>
+
+    <circle class="node fixed" cx="60" cy="60" r="16"/>
+    <text class="label" x="60" y="64" text-anchor="middle">s</text>
+    <circle class="node frontier" cx="180" cy="40" r="16"/>
+    <text class="label" x="180" y="44" text-anchor="middle">a</text>
+    <circle class="node frontier" cx="180" cy="100" r="16"/>
+    <text class="label" x="180" y="104" text-anchor="middle">b</text>
+    <circle class="node" cx="300" cy="60" r="16"/>
+    <text class="label" x="300" y="64" text-anchor="middle">t</text>
+
+    <text class="label" x="120" y="30">2</text>
+    <text class="label" x="120" y="110">5</text>
+  </g>
+
+  <!-- Panel 2 -->
+  <g transform="translate(20,190)">
+    <text class="label" x="0" y="-4">Step 2: a を確定（最小距離 2）</text>
+    <line class="edge" x1="60" y1="60" x2="180" y2="40"/>
+    <line class="edge" x1="60" y1="60" x2="180" y2="100"/>
+    <line class="best" x1="180" y1="40" x2="300" y2="60"/>
+    <line class="edge" x1="180" y1="100" x2="300" y2="60"/>
+
+    <circle class="node fixed" cx="60" cy="60" r="16"/>
+    <text class="label" x="60" y="64" text-anchor="middle">s</text>
+    <circle class="node fixed" cx="180" cy="40" r="16"/>
+    <text class="label" x="180" y="44" text-anchor="middle">a</text>
+    <circle class="node frontier" cx="180" cy="100" r="16"/>
+    <text class="label" x="180" y="104" text-anchor="middle">b</text>
+    <circle class="node" cx="300" cy="60" r="16"/>
+    <text class="label" x="300" y="64" text-anchor="middle">t</text>
+
+    <text class="label" x="240" y="30">3</text>
+  </g>
+
+  <!-- Panel 3 -->
+  <g transform="translate(360,20)">
+    <text class="label" x="0" y="-4">Step 3: t を確定（s→a→t = 5）</text>
+    <line class="best" x1="60" y1="60" x2="180" y2="40"/>
+    <line class="best" x1="180" y1="40" x2="300" y2="60"/>
+    <line class="edge" x1="60" y1="60" x2="180" y2="100"/>
+    <line class="edge" x1="180" y1="100" x2="300" y2="60"/>
+
+    <circle class="node fixed" cx="60" cy="60" r="16"/>
+    <text class="label" x="60" y="64" text-anchor="middle">s</text>
+    <circle class="node fixed" cx="180" cy="40" r="16"/>
+    <text class="label" x="180" y="44" text-anchor="middle">a</text>
+    <circle class="node" cx="180" cy="100" r="16"/>
+    <text class="label" x="180" y="104" text-anchor="middle">b</text>
+    <circle class="node fixed" cx="300" cy="60" r="16"/>
+    <text class="label" x="300" y="64" text-anchor="middle">t</text>
+  </g>
+</svg>
+

--- a/docs/src/chapter-3/index.md
+++ b/docs/src/chapter-3/index.md
@@ -269,6 +269,10 @@ NFA N = (Qₙ, Σ, δₙ, q₀, Fₙ) から DFA D = (Qᴅ, Σ, δᴅ, q₀ᴅ, 
 
 正規表現 R に対するNFA N(R) を以下の帰納的構成で作成します：
 
+直観図：Thompson 構成の各規則（リテラル・連結・和・クリーネ閉包）
+
+![Thompson 構成法：段階図](../../assets/images/diagrams/ch3_regex_to_nfa_thompson_steps.svg)
+
 **Step 1: 基本ケース**
 
 1. **空集合 ∅**:

--- a/docs/src/chapter-8/index.md
+++ b/docs/src/chapter-8/index.md
@@ -169,6 +169,10 @@ Dijkstra(G, w, s):
 *証明*（不変条件）：S に追加される頂点の d 値は最短距離に等しい。
 帰納法により証明。□
 
+例示図：Dijkstra の逐次確定（確定集合と緩和の模式図）
+
+![Dijkstra 法の逐次確定の例](../../assets/images/diagrams/ch8_dijkstra_step_trace.svg)
+
 **時間複雑度**：
 - 二分ヒープ：O((|V| + |E|) log |V|)
 - フィボナッチヒープ：O(|V| log |V| + |E|)
@@ -592,4 +596,3 @@ Gale-Shapley(男性の選好, 女性の選好):
     - 実グラフでの性能測定と分析
 
 ---
-


### PR DESCRIPTION
Adds two more pedagogical SVG diagrams and inserts them into the relevant sections.\n\n- ch3: Thompson construction steps for regex→ε-NFA\n  - file: docs/assets/images/diagrams/ch3_regex_to_nfa_thompson_steps.svg\n  - inserted under §3.3.2（正規表現からNFAへの変換プロセス）- Thompson構成の直下\n- ch8: Dijkstra step-by-step trace (settled set and relaxations)\n  - file: docs/assets/images/diagrams/ch8_dijkstra_step_trace.svg\n  - inserted under §8.2.1（単一始点最短路） after Theorem 8.5\n\nBoth follow SVG_CREATION_GUIDE (title/desc, palette, viewBox, contrast).\n\nRef #9 (diagram expansion plan).