### PR TITLE
figs(batch3): PDA stack operation + BFS vs DFS compare

### DIFF
--- a/docs/assets/images/diagrams/ch3_pda_stack_operation.svg
+++ b/docs/assets/images/diagrams/ch3_pda_stack_operation.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 360" role="img" aria-labelledby="title desc">
+  <title id="title">PDA のスタック操作（括弧整合の受理例）</title>
+  <desc id="desc">入力列に対し、PDA がスタックにプッシュ/ポップして括弧の整合を確認する様子を段階的に示す模式図。</desc>
+  <defs>
+    <style>
+      .label { fill: #111; font-family: Inter, Helvetica, Arial, sans-serif; font-size: 12px; }
+      .box { fill: #f8f9fa; stroke: #adb5bd; stroke-width: 1.5; }
+      .state { fill: #fff; stroke: #495057; stroke-width: 1.5; }
+      .accept { fill: #e6fcf5; }
+      .arrow { stroke: #212529; stroke-width: 1.8; marker-end: url(#m); }
+      .stack { fill: #fff; stroke: #495057; stroke-width: 1.2; }
+      .push { fill: #74c0fc; }
+      .pop { fill: #ffc9c9; }
+    </style>
+    <marker id="m" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#212529" />
+    </marker>
+  </defs>
+
+  <!-- Panel: input and stack actions -->
+  <g transform="translate(20,20)">
+    <rect class="box" x="0" y="0" width="680" height="320" rx="8"/>
+    <text class="label" x="10" y="18">入力: ( ( ) )</text>
+
+    <!-- step 1 -->
+    <text class="label" x="20" y="50">Step 1</text>
+    <circle class="state" cx="80" cy="72" r="14"/>
+    <text class="label" x="80" y="76" text-anchor="middle">q</text>
+    <rect class="stack push" x="120" y="58" width="24" height="28"/>
+    <text class="label" x="132" y="76" text-anchor="middle">(</text>
+    <text class="label" x="160" y="76">push '('</text>
+
+    <!-- step 2 -->
+    <text class="label" x="20" y="110">Step 2</text>
+    <circle class="state" cx="80" cy="132" r="14"/>
+    <text class="label" x="80" y="136" text-anchor="middle">q</text>
+    <rect class="stack" x="120" y="118" width="24" height="28"/>
+    <rect class="stack push" x="146" y="118" width="24" height="28"/>
+    <text class="label" x="133" y="136" text-anchor="middle">(</text>
+    <text class="label" x="158" y="136" text-anchor="middle">(</text>
+    <text class="label" x="190" y="136">push '('</text>
+
+    <!-- step 3 -->
+    <text class="label" x="20" y="170">Step 3</text>
+    <circle class="state" cx="80" cy="192" r="14"/>
+    <text class="label" x="80" y="196" text-anchor="middle">q</text>
+    <rect class="stack" x="120" y="178" width="24" height="28"/>
+    <rect class="stack pop" x="146" y="178" width="24" height="28"/>
+    <text class="label" x="133" y="196" text-anchor="middle">(</text>
+    <text class="label" x="158" y="196" text-anchor="middle">)</text>
+    <text class="label" x="190" y="196">pop '('</text>
+
+    <!-- step 4 -->
+    <text class="label" x="20" y="230">Step 4</text>
+    <circle class="state accept" cx="80" cy="252" r="14"/>
+    <text class="label" x="80" y="256" text-anchor="middle">q</text>
+    <rect class="stack pop" x="120" y="238" width="24" height="28"/>
+    <text class="label" x="133" y="256" text-anchor="middle">)</text>
+    <text class="label" x="190" y="256">pop '(' → 空スタックで受理</text>
+
+  </g>
+</svg>
+

--- a/docs/assets/images/diagrams/ch8_bfs_vs_dfs_compare.svg
+++ b/docs/assets/images/diagrams/ch8_bfs_vs_dfs_compare.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 360" role="img" aria-labelledby="title desc">
+  <title id="title">BFS と DFS の探索順と探索木の比較</title>
+  <desc id="desc">同一グラフに対して、BFS と DFS の到達順と生成される探索木の違いを2パネルで比較した図。</desc>
+  <defs>
+    <style>
+      .label { fill: #111; font-family: Inter, Helvetica, Arial, sans-serif; font-size: 12px; }
+      .node { fill: #fff; stroke: #495057; stroke-width: 1.8; }
+      .edge { stroke: #adb5bd; stroke-width: 1.4; }
+      .tree { stroke: #228be6; stroke-width: 2.2; }
+      .order { fill: #343a40; font-size: 11px; }
+      .panel { fill: #f8f9fa; stroke: #dee2e6; }
+    </style>
+  </defs>
+
+  <!-- BFS panel -->
+  <g transform="translate(20,20)">
+    <rect class="panel" x="0" y="0" width="320" height="320" rx="8"/>
+    <text class="label" x="10" y="18">BFS</text>
+    <!-- graph -->
+    <line class="edge" x1="60" y1="60" x2="160" y2="40"/>
+    <line class="edge" x1="60" y1="60" x2="160" y2="100"/>
+    <line class="edge" x1="160" y1="40" x2="260" y2="60"/>
+    <line class="edge" x1="160" y1="100" x2="260" y2="60"/>
+    <!-- BFS tree edges -->
+    <line class="tree" x1="60" y1="60" x2="160" y2="40"/>
+    <line class="tree" x1="60" y1="60" x2="160" y2="100"/>
+    <line class="tree" x1="160" y1="40" x2="260" y2="60"/>
+    <!-- nodes -->
+    <circle class="node" cx="60" cy="60" r="14"/>
+    <text class="label" x="60" y="64" text-anchor="middle">s</text>
+    <text class="order" x="60" y="80" text-anchor="middle">1</text>
+    <circle class="node" cx="160" cy="40" r="14"/>
+    <text class="label" x="160" y="44" text-anchor="middle">a</text>
+    <text class="order" x="160" y="22" text-anchor="middle">2</text>
+    <circle class="node" cx="160" cy="100" r="14"/>
+    <text class="label" x="160" y="104" text-anchor="middle">b</text>
+    <text class="order" x="160" y="122" text-anchor="middle">3</text>
+    <circle class="node" cx="260" cy="60" r="14"/>
+    <text class="label" x="260" y="64" text-anchor="middle">t</text>
+    <text class="order" x="260" y="80" text-anchor="middle">4</text>
+  </g>
+
+  <!-- DFS panel -->
+  <g transform="translate(380,20)">
+    <rect class="panel" x="0" y="0" width="320" height="320" rx="8"/>
+    <text class="label" x="10" y="18">DFS</text>
+    <!-- graph -->
+    <line class="edge" x1="60" y1="60" x2="160" y2="40"/>
+    <line class="edge" x1="60" y1="60" x2="160" y2="100"/>
+    <line class="edge" x1="160" y1="40" x2="260" y2="60"/>
+    <line class="edge" x1="160" y1="100" x2="260" y2="60"/>
+    <!-- DFS tree edges -->
+    <line class="tree" x1="60" y1="60" x2="160" y2="40"/>
+    <line class="tree" x1="160" y1="40" x2="260" y2="60"/>
+    <!-- nodes -->
+    <circle class="node" cx="60" cy="60" r="14"/>
+    <text class="label" x="60" y="64" text-anchor="middle">s</text>
+    <text class="order" x="60" y="80" text-anchor="middle">1</text>
+    <circle class="node" cx="160" cy="40" r="14"/>
+    <text class="label" x="160" y="44" text-anchor="middle">a</text>
+    <text class="order" x="160" y="22" text-anchor="middle">2</text>
+    <circle class="node" cx="260" cy="60" r="14"/>
+    <text class="label" x="260" y="64" text-anchor="middle">t</text>
+    <text class="order" x="260" y="80" text-anchor="middle">3</text>
+    <circle class="node" cx="160" cy="100" r="14"/>
+    <text class="label" x="160" y="104" text-anchor="middle">b</text>
+    <text class="order" x="160" y="122" text-anchor="middle">4</text>
+  </g>
+</svg>
+

--- a/docs/src/chapter-3/index.md
+++ b/docs/src/chapter-3/index.md
@@ -691,6 +691,10 @@ s = uvxyz と分解したとき、|vxy| ≤ p より、vxy は高々2種類の�
 
 ![プッシュダウンオートマトンの構造と機能](../../assets/images/diagrams/ch3_pushdown_automata_structure.svg)
 
+直観図：括弧整合を受理する PDA のスタック操作例
+
+![PDA のスタック操作（括弧整合）](../../assets/images/diagrams/ch3_pda_stack_operation.svg)
+
 ### 3.6.1 PDAの定義
 
 **定義 3.23** **プッシュダウンオートマトン**（PDA）は7つ組 P = (Q, Σ, Γ, δ, q₀, Z₀, F)：

--- a/docs/src/chapter-8/index.md
+++ b/docs/src/chapter-8/index.md
@@ -66,7 +66,9 @@ sections:
 
 ### 8.1.3 グラフの走査
 
-![DFS vs BFS の探索順序](../../assets/images/diagrams/ch8_dfs_bfs_comparison.svg)
+直観図：同一グラフに対する BFS と DFS の探索順・探索木の比較
+
+![BFS と DFS の比較](../../assets/images/diagrams/ch8_bfs_vs_dfs_compare.svg)
 
 #### 深さ優先探索（DFS）
 


### PR DESCRIPTION
Adds two pedagogical SVG diagrams and integrates them into chapters.\n\n- ch3: PDA stack push/pop sequence for balanced parentheses\n  - file: docs/assets/images/diagrams/ch3_pda_stack_operation.svg\n  - inserted in §3.6（PDA） after the structure figure\n- ch8: BFS vs DFS side-by-side comparison (order and tree)\n  - file: docs/assets/images/diagrams/ch8_bfs_vs_dfs_compare.svg\n  - replaces older combined figure under §8.1.3\n\nBoth follow the unified style (title/desc, palette, viewBox, contrast).\n\nRef #9 (diagram expansion plan).