### PR TITLE
figs(batch4): ch10 AWGN capacity curve + ch5 style unification (arrows/legend)

### DIFF
--- a/docs/assets/images/diagrams/ch10_awgn_capacity_curve.svg
+++ b/docs/assets/images/diagrams/ch10_awgn_capacity_curve.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420" role="img" aria-labelledby="title desc">
+  <title id="title">AWGN 通信路容量 C = (1/2) log₂(1+SNR)</title>
+  <desc id="desc">SNR に対する AWGN 通信路容量の典型的な増加曲線。縦軸は bits/channel use、横軸はSNR（線形）。代表点をマーク。</desc>
+  <defs>
+    <style>
+      .axis { stroke: #222; stroke-width: 1.5; }
+      .grid { stroke: #ddd; stroke-width: 1; }
+      .label { fill: #111; font-family: Inter, Helvetica, Arial, sans-serif; font-size: 12px; }
+      .curve { stroke: #2b8a3e; stroke-width: 3; fill: none; }
+      .pt { fill: #1c7ed6; }
+    </style>
+  </defs>
+  <g transform="translate(60,20)">
+    <!-- grid -->
+    <line class="grid" x1="0" y1="360" x2="560" y2="360"/>
+    <line class="grid" x1="0" y1="270" x2="560" y2="270"/>
+    <line class="grid" x1="0" y1="180" x2="560" y2="180"/>
+    <line class="grid" x1="0" y1="90"  x2="560" y2="90"/>
+
+    <!-- axes -->
+    <line class="axis" x1="0" y1="360" x2="560" y2="360"/>
+    <line class="axis" x1="0" y1="360" x2="0" y2="10"/>
+    <text class="label" x="565" y="365">SNR</text>
+    <text class="label" x="-12" y="12" text-anchor="end">C [bits/use]</text>
+
+    <!-- schematic curve: concave log2(1+snr) -->
+    <path class="curve" d="M0,360 C120,300 260,210 560,120"/>
+
+    <!-- reference points -->
+    <circle class="pt" cx="140" cy="300" r="4"/>
+    <text class="label" x="148" y="296">SNR≈1 → C≈0.5</text>
+    <circle class="pt" cx="280" cy="240" r="4"/>
+    <text class="label" x="288" y="236">SNR≈3 → C≈1</text>
+    <circle class="pt" cx="420" cy="190" r="4"/>
+    <text class="label" x="428" y="186">SNR≈7 → C≈1.5</text>
+  </g>
+</svg>
+

--- a/docs/assets/images/diagrams/ch5_complexity_class_inclusions.svg
+++ b/docs/assets/images/diagrams/ch5_complexity_class_inclusions.svg
@@ -12,7 +12,7 @@
       
       .inclusion-arrow { 
         stroke: #4caf50; 
-        stroke-width: 3px; 
+        stroke-width: 2.5px; 
         fill: none; 
         marker-end: url(#inclusion-arrowhead);
       }

--- a/docs/assets/images/diagrams/ch5_p_vs_np_structure.svg
+++ b/docs/assets/images/diagrams/ch5_p_vs_np_structure.svg
@@ -14,7 +14,7 @@
       
       .inclusion-arrow { 
         stroke: #4caf50; 
-        stroke-width: 3px; 
+        stroke-width: 2.5px; 
         fill: none; 
         marker-end: url(#inclusion-arrowhead);
       }

--- a/docs/src/chapter-10/index.md
+++ b/docs/src/chapter-10/index.md
@@ -344,6 +344,10 @@ C = (1/2) log₂(1 + P/N) [bits/channel use]
 帯域幅 W、信号電力 P、雑音電力 N の通信路容量：
 C = W log₂(1 + P/N) [bits/second]
 
+直観図：AWGN 容量 C = (1/2) log₂(1+SNR) の曲線
+
+![AWGN 容量曲線](../../assets/images/diagrams/ch10_awgn_capacity_curve.svg)
+
 ## 10.6 情報理論の応用
 
 ### 10.6.1 データ圧縮への応用


### PR DESCRIPTION
- Add AWGN capacity curve diagram and insert near Shannon-Hartley/AWGN capacity formulas.\n  - file: docs/assets/images/diagrams/ch10_awgn_capacity_curve.svg\n- Unify arrow stroke widths and legend panel style in key ch5 diagrams:\n  - ch5_p_vs_np_structure.svg\n  - ch5_complexity_class_inclusions.svg\n\nRef #9 (diagram expansion) and #76 (global SVG standardization).