### PR TITLE
figs(ch5 v2 pass2): accessibility + arrow width unification

### DIFF
--- a/docs/assets/images/diagrams/ch5_complexity_classes_hierarchy.svg
+++ b/docs/assets/images/diagrams/ch5_complexity_classes_hierarchy.svg
@@ -1,6 +1,6 @@
-<svg viewBox="0 0 1200 900" xmlns="http://www.w3.org/2000/svg">
-  <title>計算複雑性クラスの包含関係</title>
-  <desc>L, P, NP, PSPACE, EXPTIMEなど主要な複雑性クラスの階層構造</desc>
+<svg viewBox="0 0 1200 900" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">計算複雑性クラスの包含関係</title>
+  <desc id="desc">L, P, NP, PSPACE, EXPTIMEなど主要な複雑性クラスの階層構造</desc>
   
   <defs>
     <style>
@@ -44,7 +44,7 @@
       
       .inclusion-arrow {
         stroke: #2c3e50;
-        stroke-width: 3px;
+        stroke-width: 2.5px;
         fill: none;
         marker-end: url(#inclusion-arrowhead);
       }

--- a/docs/assets/images/diagrams/ch5_complexity_time_hierarchy.svg
+++ b/docs/assets/images/diagrams/ch5_complexity_time_hierarchy.svg
@@ -1,6 +1,6 @@
-<svg viewBox="0 0 1400 900" xmlns="http://www.w3.org/2000/svg">
-  <title>計算複雑性の階層構造</title>
-  <desc>時間複雑性、空間複雑性、非決定性クラスの包含関係と実用的境界</desc>
+<svg viewBox="0 0 1400 900" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">計算複雑性の階層構造</title>
+  <desc id="desc">時間複雑性、空間複雑性、非決定性クラスの包含関係と実用的境界</desc>
   
   <defs>
     <style>
@@ -12,7 +12,7 @@
       
       .hierarchy-arrow { 
         stroke: #666; 
-        stroke-width: 2px; 
+        stroke-width: 2.5px; 
         fill: none; 
         marker-end: url(#arrowhead);
       }


### PR DESCRIPTION
- Add role=img and aria-labelledby to ch5 classes/time hierarchy diagrams\n- Unify arrow stroke widths to 2.5px for visual consistency\n\nRef #76 (global SVG standardization).