### PR TITLE
figs(ch5): polish inclusions diagram (multi-line labels, fit within boxes)

### DIFF
--- a/docs/assets/images/diagrams/ch5_complexity_class_inclusions.svg
+++ b/docs/assets/images/diagrams/ch5_complexity_class_inclusions.svg
@@ -208,15 +208,15 @@
     <rect x="50" y="420" width="600" height="120" style="fill: #f8f9fa; stroke: #6c757d; stroke-width: 2px; rx: 8px;" />
     <text x="350" y="445" class="section-title">確実に知られている関係</text>
     
-    <text x="70" y="470" class="description">包含関係（⊆）:</text>
-    <text x="80" y="485" class="class-notation">L ⊆ NL ⊆ P ⊆ NP ⊆ PSPACE ⊆ EXPTIME</text>
-    <text x="80" y="500" class="class-notation">P ⊆ coNP ⊆ PSPACE</text>
-    <text x="80" y="515" class="class-notation">P ⊆ BPP ⊆ PSPACE</text>
+    <text x="90" y="470" class="description">包含関係（⊆）:</text>
+    <text x="100" y="485" class="class-notation">L ⊆ NL ⊆ P ⊆ NP ⊆ PSPACE ⊆ EXPTIME</text>
+    <text x="100" y="500" class="class-notation">P ⊆ coNP ⊆ PSPACE</text>
+    <text x="100" y="515" class="class-notation">P ⊆ BPP ⊆ PSPACE</text>
     
-    <text x="350" y="470" class="description">真の包含（⊊）:</text>
-    <text x="360" y="485" class="class-notation">P ⊊ EXPTIME （時間階層定理）</text>
-    <text x="360" y="500" class="class-notation">L ⊊ PSPACE （空間階層定理）</text>
-    <text x="360" y="515" class="class-notation">NL ⊊ PSPACE （Savitchの定理より）</text>
+    <text x="370" y="470" class="description">真の包含（⊊）:</text>
+    <text x="380" y="485" class="class-notation">P ⊊ EXPTIME （時間階層定理）</text>
+    <text x="380" y="500" class="class-notation">L ⊊ PSPACE （空間階層定理）</text>
+    <text x="380" y="515" class="class-notation">NL ⊊ PSPACE （Savitchの定理より）</text>
   </g>
   
   <!-- Open Questions -->
@@ -224,15 +224,15 @@
     <rect x="700" y="420" width="650" height="120" style="fill: #ffebee; stroke: #f44336; stroke-width: 2px; rx: 8px;" />
     <text x="1025" y="445" class="section-title">未解決問題</text>
     
-    <text x="720" y="470" class="description">主要な未解決問題:</text>
-    <text x="730" y="485" class="class-notation">• P vs NP （最も有名なミレニアム問題）</text>
-    <text x="730" y="500" class="class-notation">• NP vs coNP （対称性の問題）</text>
-    <text x="730" y="515" class="class-notation">• L vs P, L vs NL, NL vs P （小さなクラスの分離）</text>
+    <text x="740" y="470" class="description">主要な未解決問題:</text>
+    <text x="750" y="485" class="class-notation">• P vs NP （最も有名なミレニアム問題）</text>
+    <text x="750" y="500" class="class-notation">• NP vs coNP （対称性の問題）</text>
+    <text x="750" y="515" class="class-notation">• L vs P, L vs NL, NL vs P （小さなクラスの分離）</text>
     
-    <text x="1100" y="470" class="description">関連する未解決問題:</text>
-    <text x="1110" y="485" class="class-notation">• NP vs PSPACE</text>
-    <text x="1110" y="500" class="class-notation">• BPP vs NP, BPP vs coNP</text>
-    <text x="1110" y="515" class="class-notation">• P vs BPP （脱ランダム化）</text>
+    <text x="1120" y="470" class="description">関連する未解決問題:</text>
+    <text x="1130" y="485" class="class-notation">• NP vs PSPACE</text>
+    <text x="1130" y="500" class="class-notation">• BPP vs NP, BPP vs coNP</text>
+    <text x="1130" y="515" class="class-notation">• P vs BPP （脱ランダム化）</text>
   </g>
   
   <!-- Practical Implications -->
@@ -241,22 +241,22 @@
     <text x="700" y="605" class="section-title">実用的含意</text>
     
     <!-- Left column -->
-    <text x="70" y="630" class="description">クラス分離の重要性:</text>
-    <text x="80" y="645" class="class-notation">• P ≠ NP なら現在の暗号系は安全</text>
-    <text x="80" y="660" class="class-notation">• L ≠ P なら空間効率的アルゴリズムの限界</text>
-    <text x="80" y="675" class="class-notation">• BPP = P なら完全な脱ランダム化が可能</text>
+    <text x="90" y="630" class="description">クラス分離の重要性:</text>
+    <text x="100" y="645" class="class-notation">• P ≠ NP なら現在の暗号系は安全</text>
+    <text x="100" y="660" class="class-notation">• L ≠ P なら空間効率的アルゴリズムの限界</text>
+    <text x="100" y="675" class="class-notation">• BPP = P なら完全な脱ランダム化が可能</text>
     
     <!-- Middle column -->
-    <text x="450" y="630" class="description">アルゴリズム設計への影響:</text>
-    <text x="460" y="645" class="class-notation">• NP完全問題は近似・ヒューリスティック必要</text>
-    <text x="460" y="660" class="class-notation">• PSPACE完全問題は指数時間必要</text>
-    <text x="460" y="675" class="class-notation">• BPPのランダム化の威力</text>
+    <text x="480" y="630" class="description">アルゴリズム設計への影響:</text>
+    <text x="490" y="645" class="class-notation">• NP完全問題は近似・ヒューリスティック必要</text>
+    <text x="490" y="660" class="class-notation">• PSPACE完全問題は指数時間必要</text>
+    <text x="490" y="675" class="class-notation">• BPPのランダム化の威力</text>
     
     <!-- Right column -->
-    <text x="850" y="630" class="description">研究の方向性:</text>
-    <text x="860" y="645" class="class-notation">• 下界証明技法の開発</text>
-    <text x="860" y="660" class="class-notation">• 新しい計算モデルの探求</text>
-    <text x="860" y="675" class="class-notation">• 量子・近似・並列複雑性との関係</text>
+    <text x="880" y="630" class="description">研究の方向性:</text>
+    <text x="890" y="645" class="class-notation">• 下界証明技法の開発</text>
+    <text x="890" y="660" class="class-notation">• 新しい計算モデルの探求</text>
+    <text x="890" y="675" class="class-notation">• 量子・近似・並列複雑性との関係</text>
   </g>
   
   <!-- Visual aids for uncertain relationships -->


### PR DESCRIPTION
Final polish for ch5 complexity class inclusions diagram:\n- Split long Japanese labels into two lines (非決定性/多項式時間 等)\n- Adjust y positions to fit within 100×60 boxes\n- Keeps .small font for readability\n\nRef #76 (global SVG standardization).