### PR TITLE
chore: add stale issue workflow + TRIAGE guide; update a11y report and HANDOFF

### DIFF
--- a/.github/TRIAGE.md
+++ b/.github/TRIAGE.md
@@ -1,0 +1,58 @@
+# Issue トリアージ方針（運用メモ）
+
+このリポジトリのIssuesを効率よく管理するための手順です。
+
+## 優先度ラベル
+
+- `priority: high` — ビルド/閲覧不能、内容の誤り（学習者影響大）、セキュリティ
+- `priority: medium` — 品質改善（図/文面/ナビゲーション）
+- `priority: low` — 細かなリファクタ、提案、将来要望
+
+補助ラベル: `bug`, `a11y`, `docs`, `content`, `diagram`, `dependencies`
+
+## クローズポリシー
+
+- 120日以上アクティビティ無しのIssueは自動で `stale`（ワークフローで運用）
+- 14日間無反応なら自動クローズ（例外: `priority: high`, `security`, `bug`, `pinned`, `dependencies`）
+- 再現手順や情報不足のものは `needs-more-info` を付けてコメント→2週間でクローズ候補
+
+## トリアージ手順（定例）
+
+1) オープンIssuesを確認（最新100件）
+
+```bash
+gh issue list -R itdojp/theoretical-computer-science-textbook --state open --limit 100 --sort updated
+```
+
+2) 重要度順に並べ替え・ラベル付与
+
+```bash
+# 例: 明確な内容誤り
+gh issue edit <num> -R itdojp/theoretical-computer-science-textbook --add-label "bug,priority: high,content"
+
+# 例: 図の改善要望
+gh issue edit <num> -R itdojp/theoretical-computer-science-textbook --add-label "diagram,priority: medium"
+```
+
+3) 古い/解決済みのクローズ
+
+```bash
+# 明確に解決済み（該当PR/コミット有）
+gh issue close <num> -R itdojp/theoretical-computer-science-textbook \
+  -c "現在の main にて解消済みのためクローズします。問題が続く場合はreopenください。"
+
+# 情報不足
+gh issue comment <num> -R itdojp/theoretical-computer-science-textbook \
+  -b "再現手順と使用環境の詳細をご提供ください。2週間無反応の場合はクローズします。"
+gh issue edit <num> -R itdojp/theoretical-computer-science-textbook --add-label needs-more-info
+```
+
+4) 高優先度の即時対応
+
+- 直接修正 or 再現→修正→PR。PRテンプレートに「修正内容/再現/影響範囲/スクショ」を添付。
+
+## 備考
+
+- a11y（SVG）は現状全件対応済み。新規追加分のみ監視。
+- 8章ネットワークフロー関連は補助図・脚注整備済み。追加要望は `diagram` ラベルに集約。
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+name: Auto-stale and close inactive issues
+
+on:
+  schedule:
+    - cron: '30 3 * * *' # daily at 03:30 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 120
+          days-before-close: 14
+          remove-stale-when-updated: true
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'priority: high,security,bug,pinned,dependencies'
+          stale-issue-message: |
+            このIssueは120日間アクティビティが無かったため自動的にstaleとマークされました。
+            - まだ有効な場合はコメントを追加して維持してください（ラベルは自動で外れます）。
+            - 14日以内にアクティビティが無い場合は自動的にクローズされます。
+            例外ラベル（priority: high, security, bug, pinned, dependencies）が付いたIssueは対象外です。
+          close-issue-message: |
+            アクティビティが無かったため自動クローズされました。必要であれば再オープンしてください。
+          stale-pr-message: ''
+          close-pr-message: ''
+          operations-per-run: 200
+

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,82 @@
+# 引き継ぎノート（一時停止前のサマリ）
+
+このドキュメントは、今回の改善作業の到達点・変更点・残タスクを簡潔にまとめたものです。次回の再開時の着手ポイントとして利用してください。
+
+## 到達点（主な内容改善）
+
+- 第4章（計算可能性）
+  - Rice の定理の内容強化（厳密な主張、還元スケッチ、適用チェックリスト、例）。
+  - 章内クロスリンクと用語集連携（「補有限(cofinite)」など）。
+  - 章末ミニ演習を追加（REGULAR_TM の非決定可能性、固定語包含性）。
+  - 付録Cに対応する解答を追加。
+
+- 第5章（計算複雑性）
+  - 還元のサイズ管理（3-SAT→Vertex-Cover、Cook–Levin）を章末に追加。
+  - 付録Cにサイズ管理の解答（概算）を追加。
+
+- 第8章（グラフ・フロー）
+  - Dijkstra の負辺カウンタ例図を追加し、適用条件の注意を明示。
+  - 最大フロー最小カットの直観図を追加し、適用のコツを明記。
+  - 残余グラフでの「増加路1ステップ」図を追加し、ミニ例の直後に挿入。
+  - 用語集へのアンカー付きクロスリンク（残余グラフ/残余ネットワーク、逆向き辺、レベルグラフ、ブロッキングフロー、カット）を整備。
+
+- 第3章（形式言語）
+  - Myhill–Nerode の直観図（接頭辞による識別可能性）を追加。
+  - 章末に Myhill–Nerode を用いた最小DFA下界の演習を追加、付録Cに解答追加。
+
+- 付録D（用語集）
+  - 新規項目とアンカーを追加：
+    - 残余ネットワーク、逆向き辺、最小カット
+    - 既存：増加路/補有限/カット/レベルグラフ/残余グラフ/残余容量/ブロッキングフロー にアンカー付与
+
+## 追加・更新した主な図版（SVG）
+
+- docs/assets/images/diagrams/ch8_dijkstra_negative_edge_counterexample.svg（新規）
+- docs/assets/images/diagrams/ch8_maxflow_mincut_intuition.svg（新規）
+- docs/assets/images/diagrams/ch8_augmenting_path_step.svg（新規）
+- docs/assets/images/diagrams/ch3_myhill_nerode_prefix_distinguish.svg（新規）
+- 既存多数のSVGに a11y メタデータ（role/aria-labelledby と title/desc の id）を付与
+
+## ツールとチェック方法
+
+- 図版インベントリ: `bash scripts/diagrams-inventory.sh`
+- SVG 構造チェック: `bash scripts/svg-lint.sh docs/assets/images/diagrams`
+- SVG a11y チェック（POSIX互換）: `bash scripts/svg-lint-a11y.sh`
+  - 未対応の既存SVGが多数あります（非致命）。段階的に対応予定。
+
+## 残タスク（優先度順）
+
+現時点で以下は対応済み：
+
+1) SVG アクセシビリティの継続改善（role/aria-labelledby/title(id)/desc(id)）
+   - docs/assets/images/diagrams 配下の全SVGに付与済み。
+   - スクリプト結果: OK（all SVGs include role/title[id]/desc/aria-labelledby）。レポート更新済み。
+
+2) 用語集の微拡充と初出時フットノート連携（第8章中心 + 第4章）
+   - 第8章: 残余グラフ/増加路/カット/レベルグラフ/ブロッキングフローに【用語の脚注】を併記
+   - 第4章: 補有限に【用語の脚注】を併記
+
+3) 第8章の直観補強
+   - 増加路 Before/After の二面図を追加し、8.4.2に挿入済み
+
+4) 第4章の仕上げ
+   - Rice の定理の適用例（FINITE_TM, COFINITE_TM）を付録Cに追加済み
+
+今後の候補（新規）
+- 8章: 最小カットの別バリエーション図が必要であれば作成
+- 他章: 用語初出への【用語の脚注】適用範囲を拡大（要アンカー整備）
+
+## 既知の注意点
+
+- 第4章は 4.4 に Rice の定理を集約済み。4.1 近辺に重複セクションはありません（整合性確認済）。
+- a11y チェックは新規・改修分は適合。既存の多くは段階対応の方針です。
+
+## 再開時のおすすめ着手順
+
+1. `bash scripts/svg-lint-a11y.sh` を実行し、未対応SVGから 5〜10 本ずつ a11y メタデータを追加。
+2. 第8章の Before/After 図を追加するか判断（必要であれば作成して 8.4.2 に並置）。
+3. 用語集の補完（必要語彙が出た時点でアンカー付きで追記）。
+
+---
+
+メンテナ：今回の変更は全てローカルのワークスペースに反映済みです。スクリプトは POSIX sh 互換で動作します。

--- a/reports/svg-a11y-backlog.txt
+++ b/reports/svg-a11y-backlog.txt
@@ -1,0 +1,10 @@
+# SVG a11y backlog（要 role/title(id)/desc(id)/aria-labelledby）
+
+このファイルは、`bash scripts/svg-lint-a11y.sh` の最近の実行結果に基づく未対応図版のメモです。
+最新状況はスクリプトを再実行して確認してください。
+
+最終確認日時（自動更新ではありません）: 現在の作業時点
+
+現在の状況:
+- スクリプト結果: OK（all SVGs include role/title[id]/desc/aria-labelledby）
+- 未対応0件（新規追加や外部由来のSVGが増えた場合は再実行してください）


### PR DESCRIPTION
- Add auto-stale workflow for inactive issues (120d stale / 14d auto-close, with exceptions)\n- Add .github/TRIAGE.md with triage policy and gh commands\n- Update reports/svg-a11y-backlog.txt to current status (all compliant)\n- Update HANDOFF.md to reflect completed tasks and next candidates\n\nThis PR helps keep Issues clean and makes regular triage repeatable.\nIf approved, Actions will mark stale and close old, inactive issues automatically.