### PR TITLE
fix(stage2): chapter titleをH1に整合

### DIFF
--- a/docs/src/chapter-10/index.md
+++ b/docs/src/chapter-10/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "情報理論"
+title: "第10章 情報理論"
 subtitle: "情報の定量化と符号化"
 chapter: 10
 description: "情報の数学的基礎と通信理論"

--- a/docs/src/chapter-11/index.md
+++ b/docs/src/chapter-11/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "暗号理論の数学的基礎"
+title: "第11章 暗号理論の数学的基礎"
 subtitle: "現代暗号の理論的基盤"
 chapter: 11
 description: "暗号システムの安全性と数学的根拠"

--- a/docs/src/chapter-12/index.md
+++ b/docs/src/chapter-12/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "並行計算の理論"
+title: "第12章 並行計算の理論"
 subtitle: "並列・分散システムの理論的基礎"
 chapter: 12
 description: "並行計算の数学的モデルと解析"

--- a/docs/src/chapter-4/index.md
+++ b/docs/src/chapter-4/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第4章 計算可能性"
+title: "第4章 計算可能性理論"
 subtitle: "決定可能性と還元可能性"
 description: "計算の本質的な限界を数学的に証明"
 chapter: 4

--- a/docs/src/chapter-7/index.md
+++ b/docs/src/chapter-7/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "データ構造の理論"
+title: "第7章 データ構造の理論"
 subtitle: "効率的なデータ操作の基盤"
 chapter: 7
 description: "理論的観点から見たデータ構造の設計と解析"

--- a/docs/src/chapter-8/index.md
+++ b/docs/src/chapter-8/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "グラフ理論とネットワーク"
+title: "第8章 グラフ理論とネットワーク"
 subtitle: "グラフアルゴリズムと応用"
 chapter: 8
 description: "グラフ理論の基礎からネットワーク解析まで"

--- a/docs/src/chapter-9/index.md
+++ b/docs/src/chapter-9/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "論理学・形式的手法"
+title: "第9章 論理学と形式的手法"
 subtitle: "プログラム検証と形式仕様"
 chapter: 9
 description: "論理学に基づくプログラムの正当性保証"


### PR DESCRIPTION
## 目的
章ページの front matter `title` と本文の章見出し（H1）を一致させ、
ナビゲーション（prev/next / タイトル表示）の一貫性を上げます。

## 変更点
- 対象: `docs/src/chapter-4,7,8,9,10,11,12/index.md`
- 変更: `title` のみ（本文は変更なし）
