### PR TITLE
fix: 導入ページのfront matter重複とH1不足を解消

### DIFF
--- a/docs/src/introduction/learning-guide.md
+++ b/docs/src/introduction/learning-guide.md
@@ -1,11 +1,9 @@
 ---
 layout: book
+title: "学習の進め方"
 ---
 
----
-title: "学習の進め方"
-layout: default
----
+# 学習の進め方
 
 ## 基本的な学習戦略
 

--- a/docs/src/introduction/prerequisites.md
+++ b/docs/src/introduction/prerequisites.md
@@ -1,11 +1,9 @@
 ---
 layout: book
+title: "前提知識"
 ---
 
----
-title: "前提知識"
-layout: default
----
+# 前提知識
 
 ## 必要な数学的基礎
 


### PR DESCRIPTION
導入セクションの一部ページで front matter が2重になっており、また本文先頭にH1が無い状態でした。\n\n- 対象: `docs/src/introduction/prerequisites.md`, `docs/src/introduction/learning-guide.md`\n- 変更: front matter を1つに統合（`layout: book` + `title`）、先頭にH1を追加\n- 備考: `purpose.md` は別PRで改修中のため本PRでは未変更