### PR TITLE
Stage3: 第5章の章末問題リンク表記を整合

### DIFF
--- a/docs/src/chapter-5/index.md
+++ b/docs/src/chapter-5/index.md
@@ -30,7 +30,7 @@ chapter: 5
 
 ## 章末問題
 
-- 代表演習と詳細解答は付録C（第5章）を参照: ../appendices/c/#ex-sol-ch5
+- 代表演習と詳細解答は [付録C（第5章）](../appendices/c/#ex-sol-ch5) を参照。
 
 ## 5.1 時間複雑性
 


### PR DESCRIPTION
Stage3（表現・スタイル）の小さめPRです。

- 対象: `docs/src/chapter-5/index.md`
- 変更内容: 「章末問題」の参照先表記を、他章と同じ Markdown リンク形式に統一
  - `...を参照: ../appendices/c/#ex-sol-ch5` → `...[付録C（第5章）](../appendices/c/#ex-sol-ch5) を参照。`
- 目的: 表記ゆれを減らし、参照先をクリックしやすくする（文意は変更しない）
