### PR TITLE
Stage3: 学習期間の範囲表記を統一（estimated_time）

### DIFF
--- a/docs/src/chapter-10/index.md
+++ b/docs/src/chapter-10/index.md
@@ -4,7 +4,7 @@ title: "第10章 情報理論"
 subtitle: "情報の定量化と符号化"
 chapter: 10
 description: "情報の数学的基礎と通信理論"
-estimated_time: "3-4週間"
+estimated_time: "3〜4週間"
 difficulty: "★★★☆"
 sections:
   - "情報量とエントロピー"

--- a/docs/src/chapter-11/index.md
+++ b/docs/src/chapter-11/index.md
@@ -4,7 +4,7 @@ title: "第11章 暗号理論の数学的基礎"
 subtitle: "現代暗号の理論的基盤"
 chapter: 11
 description: "暗号システムの安全性と数学的根拠"
-estimated_time: "4-5週間"
+estimated_time: "4〜5週間"
 difficulty: "★★★★"
 sections:
   - "暗号の基本概念"

--- a/docs/src/chapter-12/index.md
+++ b/docs/src/chapter-12/index.md
@@ -4,7 +4,7 @@ title: "第12章 並行計算の理論"
 subtitle: "並列・分散システムの理論的基礎"
 chapter: 12
 description: "並行計算の数学的モデルと解析"
-estimated_time: "3-4週間"
+estimated_time: "3〜4週間"
 difficulty: "★★★★"
 sections:
   - "並行計算モデル"

--- a/docs/src/chapter-7/index.md
+++ b/docs/src/chapter-7/index.md
@@ -4,7 +4,7 @@ title: "第7章 データ構造の理論"
 subtitle: "効率的なデータ操作の基盤"
 chapter: 7
 description: "理論的観点から見たデータ構造の設計と解析"
-estimated_time: "4-5週間"
+estimated_time: "4〜5週間"
 difficulty: "★★★☆"
 sections:
   - "基本データ構造"

--- a/docs/src/chapter-8/index.md
+++ b/docs/src/chapter-8/index.md
@@ -4,7 +4,7 @@ title: "第8章 グラフ理論とネットワーク"
 subtitle: "グラフアルゴリズムと応用"
 chapter: 8
 description: "グラフ理論の基礎からネットワーク解析まで"
-estimated_time: "5-6週間"
+estimated_time: "5〜6週間"
 difficulty: "★★★☆"
 sections:
   - "グラフの基本概念"

--- a/docs/src/chapter-9/index.md
+++ b/docs/src/chapter-9/index.md
@@ -4,7 +4,7 @@ title: "第9章 論理学と形式的手法"
 subtitle: "プログラム検証と形式仕様"
 chapter: 9
 description: "論理学に基づくプログラムの正当性保証"
-estimated_time: "4-5週間"
+estimated_time: "4〜5週間"
 difficulty: "★★★★"
 sections:
   - "命題論理と述語論理"


### PR DESCRIPTION
Stage3（表現・スタイル）の小さめPRです。

- 対象: `docs/src/chapter-7/index.md` ほか（chapter-7〜12）
- 変更内容: front matter の `estimated_time` の範囲表記を統一（`-` → `〜`）
  - 例: `4-5週間` → `4〜5週間`
- 目的: 範囲表記の表記ゆれを減らし、見た目の一貫性を高める（文意は変更しない）
