### PR TITLE
docs: 形式検証の最小実行例（Z3/TLA+/Lean）を追加

### DIFF
--- a/docs/assets/examples/formal-methods/lean/Simple.lean
+++ b/docs/assets/examples/formal-methods/lean/Simple.lean
@@ -1,0 +1,10 @@
+-- Minimal Lean example (Chapter 9).
+-- The goal is to show how to state and prove a small theorem in a proof assistant.
+
+theorem add_zero (n : Nat) : n + 0 = n := by
+  rfl
+
+theorem and_swap (p q : Prop) : p ∧ q -> q ∧ p := by
+  intro h
+  exact And.intro h.right h.left
+

--- a/docs/assets/examples/formal-methods/tla/Peterson.cfg
+++ b/docs/assets/examples/formal-methods/tla/Peterson.cfg
@@ -1,0 +1,6 @@
+INIT Init
+NEXT Next
+
+INVARIANT TypeOK
+INVARIANT MutualExclusion
+

--- a/docs/assets/examples/formal-methods/tla/Peterson.tla
+++ b/docs/assets/examples/formal-methods/tla/Peterson.tla
@@ -1,0 +1,64 @@
+---- MODULE Peterson ----
+EXTENDS Naturals, TLC
+
+(*
+  Minimal TLA+ model for Peterson's mutual exclusion algorithm (2 processes).
+  Intended for TLC model checking (safety: mutual exclusion).
+*)
+
+Proc == {0, 1}
+Other(p) == 1 - p
+
+VARIABLES flag, turn, pc
+
+TypeOK ==
+  /\ flag \in [Proc -> BOOLEAN]
+  /\ turn \in Proc
+  /\ pc \in [Proc -> {"start", "setturn", "wait", "cs", "exit"}]
+
+Init ==
+  /\ flag = [p \in Proc |-> FALSE]
+  /\ turn = 0
+  /\ pc = [p \in Proc |-> "start"]
+
+Start(p) ==
+  /\ pc[p] = "start"
+  /\ flag' = [flag EXCEPT ![p] = TRUE]
+  /\ pc' = [pc EXCEPT ![p] = "setturn"]
+  /\ UNCHANGED turn
+
+SetTurn(p) ==
+  /\ pc[p] = "setturn"
+  /\ turn' = Other(p)
+  /\ pc' = [pc EXCEPT ![p] = "wait"]
+  /\ UNCHANGED flag
+
+Wait(p) ==
+  /\ pc[p] = "wait"
+  /\ ~(flag[Other(p)] /\ turn = Other(p))
+  /\ pc' = [pc EXCEPT ![p] = "cs"]
+  /\ UNCHANGED <<flag, turn>>
+
+ExitCS(p) ==
+  /\ pc[p] = "cs"
+  /\ pc' = [pc EXCEPT ![p] = "exit"]
+  /\ UNCHANGED <<flag, turn>>
+
+Release(p) ==
+  /\ pc[p] = "exit"
+  /\ flag' = [flag EXCEPT ![p] = FALSE]
+  /\ pc' = [pc EXCEPT ![p] = "start"]
+  /\ UNCHANGED turn
+
+Step(p) == Start(p) \/ SetTurn(p) \/ Wait(p) \/ ExitCS(p) \/ Release(p)
+
+Next == \E p \in Proc : Step(p)
+
+MutualExclusion == ~(pc[0] = "cs" /\ pc[1] = "cs")
+
+Spec == Init /\ [][Next]_<<flag, turn, pc>>
+
+THEOREM Spec => []MutualExclusion
+
+====
+

--- a/docs/assets/examples/formal-methods/z3/sat_demo.py
+++ b/docs/assets/examples/formal-methods/z3/sat_demo.py
@@ -1,0 +1,46 @@
+"""Minimal SAT/SMT example using Z3 (Chapter 9).
+
+Usage (example):
+  python3 -m venv .venv
+  . .venv/bin/activate
+  pip install z3-solver
+  python sat_demo.py
+"""
+
+from __future__ import annotations
+
+from z3 import And, Bool, Not, Or, Solver, sat
+
+
+def main() -> None:
+    # Example 1: UNSAT (p ∧ ¬p)
+    p = Bool("p")
+    s1 = Solver()
+    s1.add(And(p, Not(p)))
+    print("[example 1] p AND (NOT p)")
+    print("  result:", s1.check())
+
+    # Example 2: small 3-SAT-style CNF from Chapter 9 exercises (SAT/UNSAT depends on constraints).
+    p = Bool("p")
+    q = Bool("q")
+    r = Bool("r")
+
+    cnf = And(
+        Or(p, q, r),
+        Or(Not(p), Not(q)),
+        Or(Not(q), Not(r)),
+        Or(Not(r), Not(p)),
+    )
+
+    s2 = Solver()
+    s2.add(cnf)
+    print("[example 2] (p ∨ q ∨ r) ∧ (¬p ∨ ¬q) ∧ (¬q ∨ ¬r) ∧ (¬r ∨ ¬p)")
+    res = s2.check()
+    print("  result:", res)
+    if res == sat:
+        print("  model:", s2.model())
+
+
+if __name__ == "__main__":
+    main()
+

--- a/docs/chapter-12/index.md
+++ b/docs/chapter-12/index.md
@@ -241,6 +241,21 @@ Kripke 構造 M = (S, S₀, R, L)
 ![ABA問題の概念図]({{ '/assets/images/diagrams/ch12_aba_problem_diagram.svg' | relative_url }})
 - 粒度: ロック粒度と競合率のトレードオフ。読み取り多い場合はRWロックも選択肢。
 
+### 12.4.4 最小実行例（TLA+ / TLC）
+
+ここでは、2プロセス相互排除（Peterson）を有限状態でモデル化し、安全性（相互排除）をモデル検査で確認する最小例を示します。
+
+- 例ファイル：[`Peterson.tla`]({{ '/assets/examples/formal-methods/tla/Peterson.tla' | relative_url }}), [`Peterson.cfg`]({{ '/assets/examples/formal-methods/tla/Peterson.cfg' | relative_url }})
+- 必要要件：TLC（TLA+ Toolbox または `tla2tools.jar`）、（CLI実行する場合は）Java
+
+```bash
+# tla2tools.jar を用いるCLI実行例（jarの入手/配置は環境に依存）
+cd docs/assets/examples/formal-methods/tla
+java -cp tla2tools.jar tlc2.TLC -config Peterson.cfg Peterson.tla
+```
+
+注：モデル検査の基本概念（性質の書き方、状態爆発と対策）は第9章も参照してください。
+
 ## 12.5 分散アルゴリズム
 
 ### 12.5.1 分散システムのモデル

--- a/docs/chapter-9/index.md
+++ b/docs/chapter-9/index.md
@@ -443,6 +443,36 @@ Qed.
 - 自動化の限界
 - 抽象化のギャップ
 
+### 9.6.4 最小実行例（SAT/SMT / 定理証明）
+
+以下は「手元で動く」最小例です。目的は (1) 充足可能性を機械判定する、(2) 短い定理を証明支援系で形式化する、の2点です。
+
+#### SAT/SMT: Z3（Python）
+
+- 例ファイル：[`sat_demo.py`]({{ '/assets/examples/formal-methods/z3/sat_demo.py' | relative_url }})
+- 必要要件：Python 3.11+、`z3-solver`（pip）
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+pip install z3-solver
+cd docs/assets/examples/formal-methods/z3
+python sat_demo.py
+```
+
+#### 定理証明: Lean（Lean4）
+
+- 例ファイル：[`Simple.lean`]({{ '/assets/examples/formal-methods/lean/Simple.lean' | relative_url }})
+- 必要要件：Lean4 CLI（導入手順は環境に依存するため、本書では固定しない）
+
+```bash
+# Lean4 がインストール済みの環境で
+cd docs/assets/examples/formal-methods/lean
+lean Simple.lean
+```
+
+注：モデル検査の最小例は、第12章のTLA+（TLC）例も参照してください。
+
 ## 章末問題
 
 ### 基礎問題

--- a/src/chapter-12/index.md
+++ b/src/chapter-12/index.md
@@ -241,6 +241,21 @@ Kripke 構造 M = (S, S₀, R, L)
 ![ABA問題の概念図]({{ '/assets/images/diagrams/ch12_aba_problem_diagram.svg' | relative_url }})
 - 粒度: ロック粒度と競合率のトレードオフ。読み取り多い場合はRWロックも選択肢。
 
+### 12.4.4 最小実行例（TLA+ / TLC）
+
+ここでは、2プロセス相互排除（Peterson）を有限状態でモデル化し、安全性（相互排除）をモデル検査で確認する最小例を示します。
+
+- 例ファイル：[`Peterson.tla`]({{ '/assets/examples/formal-methods/tla/Peterson.tla' | relative_url }}), [`Peterson.cfg`]({{ '/assets/examples/formal-methods/tla/Peterson.cfg' | relative_url }})
+- 必要要件：TLC（TLA+ Toolbox または `tla2tools.jar`）、（CLI実行する場合は）Java
+
+```bash
+# tla2tools.jar を用いるCLI実行例（jarの入手/配置は環境に依存）
+cd docs/assets/examples/formal-methods/tla
+java -cp tla2tools.jar tlc2.TLC -config Peterson.cfg Peterson.tla
+```
+
+注：モデル検査の基本概念（性質の書き方、状態爆発と対策）は第9章も参照してください。
+
 ## 12.5 分散アルゴリズム
 
 ### 12.5.1 分散システムのモデル

--- a/src/chapter-9/index.md
+++ b/src/chapter-9/index.md
@@ -443,6 +443,36 @@ Qed.
 - 自動化の限界
 - 抽象化のギャップ
 
+### 9.6.4 最小実行例（SAT/SMT / 定理証明）
+
+以下は「手元で動く」最小例です。目的は (1) 充足可能性を機械判定する、(2) 短い定理を証明支援系で形式化する、の2点です。
+
+#### SAT/SMT: Z3（Python）
+
+- 例ファイル：[`sat_demo.py`]({{ '/assets/examples/formal-methods/z3/sat_demo.py' | relative_url }})
+- 必要要件：Python 3.11+、`z3-solver`（pip）
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+pip install z3-solver
+cd docs/assets/examples/formal-methods/z3
+python sat_demo.py
+```
+
+#### 定理証明: Lean（Lean4）
+
+- 例ファイル：[`Simple.lean`]({{ '/assets/examples/formal-methods/lean/Simple.lean' | relative_url }})
+- 必要要件：Lean4 CLI（導入手順は環境に依存するため、本書では固定しない）
+
+```bash
+# Lean4 がインストール済みの環境で
+cd docs/assets/examples/formal-methods/lean
+lean Simple.lean
+```
+
+注：モデル検査の最小例は、第12章のTLA+（TLC）例も参照してください。
+
 ## 章末問題
 
 ### 基礎問題


### PR DESCRIPTION
Closes #178

## 変更内容
- 形式検証/論理パートに「手元で動く」最小例を追加
  - SAT/SMT（Z3 / Python）: `docs/assets/examples/formal-methods/z3/sat_demo.py`
  - モデル検査（TLA+ / TLC）: `docs/assets/examples/formal-methods/tla/Peterson.tla` + `Peterson.cfg`
  - 定理証明（Lean4）: `docs/assets/examples/formal-methods/lean/Simple.lean`
- 章内に実行手順（依存関係/コマンド）を追記
  - `docs/chapter-9/index.md` / `src/chapter-9/index.md`
  - `docs/chapter-12/index.md` / `src/chapter-12/index.md`

## ねらい
- 読者が「仕様→検査/証明」を最小ステップで再現できる導線を提供する

## 備考
- 各ツールのインストール手順は環境差が大きいため、CLI実行例は最小限の前提に留めています。}