### PR TITLE
fix: SVG内テキストの< >をエスケープ（Release Artifacts向け）

### DIFF
--- a/docs/assets/images/diagrams/ch10_channel_models_capacity.svg
+++ b/docs/assets/images/diagrams/ch10_channel_models_capacity.svg
@@ -190,8 +190,8 @@
     <rect x="700" y="420" width="600" height="160" class="theorem-box" />
     <text x="710" y="440" class="model-title">定理の内容</text>
     <text x="720" y="460" class="description">通信路容量 C に対して:</text>
-    <text x="730" y="480" class="description">• R < C なら、任意に小さい誤り確率で通信可能</text>
-    <text x="730" y="495" class="description">• R > C なら、誤り確率を小さくできない</text>
+    <text x="730" y="480" class="description">• R &lt; C なら、任意に小さい誤り確率で通信可能</text>
+    <text x="730" y="495" class="description">• R &gt; C なら、誤り確率を小さくできない</text>
     <text x="720" y="520" class="description">ここで R は情報レート（bit/チャネル使用）</text>
     
     <text x="710" y="550" class="model-title">実用的含意</text>

--- a/docs/assets/images/diagrams/ch10_information_entropy_concepts.svg
+++ b/docs/assets/images/diagrams/ch10_information_entropy_concepts.svg
@@ -89,7 +89,7 @@
     <text x="120" y="235" class="property-text">• p = 1 なら I(p) = 0（確実な事象は情報量0）</text>
     <text x="120" y="250" class="property-text">• p が小さいほど I(p) が大きい（稀な事象ほど情報価値高）</text>
     <text x="120" y="265" class="property-text">• 独立事象は加法的：I(p₁ · p₂) = I(p₁) + I(p₂)</text>
-    <text x="120" y="280" class="property-text">• 単調減少関数：p₁ < p₂ なら I(p₁) > I(p₂)</text>
+    <text x="120" y="280" class="property-text">• 単調減少関数：p₁ &lt; p₂ なら I(p₁) &gt; I(p₂)</text>
     <text x="120" y="295" class="property-text">• I(1/2) = 1 bit（コイン投げの情報量）</text>
     
     <!-- Examples -->

--- a/docs/assets/images/diagrams/ch11_cryptographic_systems_overview.svg
+++ b/docs/assets/images/diagrams/ch11_cryptographic_systems_overview.svg
@@ -200,7 +200,7 @@
     <text x="335" y="365" class="description">• 実用的な安全性レベル</text>
     <text x="335" y="380" class="description">• 優位性が無視できる程度に小さい</text>
     <text x="335" y="395" class="description">• 例：AES、RSA、ECC</text>
-    <text x="445" y="415" class="formula">Adv < negl(n)</text>
+    <text x="445" y="415" class="formula">Adv &lt; negl(n)</text>
     
     <!-- Computational Assumptions -->
     <rect x="590" y="310" width="260" height="120" class="concept-box security-box" />

--- a/docs/assets/images/diagrams/ch11_cryptography_basics.svg
+++ b/docs/assets/images/diagrams/ch11_cryptography_basics.svg
@@ -170,7 +170,7 @@
     <text x="380" y="410" class="crypto-text">• 例：AES, RSA</text>
     <text x="380" y="425" class="crypto-text">• 計算量仮定に依存</text>
     <text x="380" y="440" class="crypto-text">• 現実的な運用が可能</text>
-    <text x="380" y="455" class="math-text">Pr[Attack] < negl(n)</text>
+    <text x="380" y="455" class="math-text">Pr[Attack] &lt; negl(n)</text>
     
     <!-- Computational assumptions -->
     <rect x="50" y="480" width="620" height="60" class="security-class" />
@@ -209,7 +209,7 @@
     
     <!-- Attack strength comparison -->
     <rect x="750" y="460" width="640" height="60" class="attack-model" />
-    <text x="760" y="480" class="crypto-title">攻撃の強さ：CCA > CPA > KPA</text>
+    <text x="760" y="480" class="crypto-title">攻撃の強さ：CCA &gt; CPA &gt; KPA</text>
     <text x="760" y="500" class="crypto-text">• より強い攻撃に耐性があれば、弱い攻撃にも耐性がある</text>
     <text x="760" y="515" class="crypto-text">• 実用的なシステムでは適切な攻撃モデルを想定する必要がある</text>
   </g>

--- a/docs/assets/images/diagrams/ch11_rsa_cryptosystem.svg
+++ b/docs/assets/images/diagrams/ch11_rsa_cryptosystem.svg
@@ -188,7 +188,7 @@
     <!-- Strong RSA assumption -->
     <rect x="1070" y="360" width="280" height="80" class="security-aspect" />
     <text x="1080" y="380" class="step-title">強RSA仮定</text>
-    <text x="1080" y="400" class="explanation">任意の e > 1 に対して</text>
+    <text x="1080" y="400" class="explanation">任意の e &gt; 1 に対して</text>
     <text x="1080" y="415" class="explanation">e 乗根を求めるのは困難</text>
     <text x="1080" y="430" class="explanation">より強い安全性の根拠</text>
   </g>

--- a/docs/assets/images/diagrams/ch3_context_free_languages_grammars.svg
+++ b/docs/assets/images/diagrams/ch3_context_free_languages_grammars.svg
@@ -221,7 +221,7 @@
     <text x="460" y="760" text-anchor="middle" font-family="Inter, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#d32f2f">条件</text>
     <text x="370" y="780" font-family="Inter, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#d32f2f">1. |vxy| ≤ p</text>
     <text x="380" y="795" font-family="Inter, Helvetica, sans-serif" font-size="9" fill="#777">中央部分は短い</text>
-    <text x="370" y="810" font-family="Inter, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#d32f2f">2. |vy| > 0</text>
+    <text x="370" y="810" font-family="Inter, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#d32f2f">2. |vy| &gt; 0</text>
     <text x="380" y="825" font-family="Inter, Helvetica, sans-serif" font-size="9" fill="#777">vとyは同時に空でない</text>
     <text x="370" y="840" font-family="Inter, Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#d32f2f">3. vとyを同時にpumping</text>
     

--- a/docs/assets/images/diagrams/ch3_pumping_lemma_limitations.svg
+++ b/docs/assets/images/diagrams/ch3_pumping_lemma_limitations.svg
@@ -33,7 +33,7 @@
     <text x="345" y="140" text-anchor="middle" font-family="Inter, Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#1976d2">条件</text>
     <text x="280" y="165" font-family="Inter, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#d32f2f">1. |xy| ≤ p</text>
     <text x="290" y="180" font-family="Inter, Helvetica, sans-serif" font-size="10" fill="#777">ループは最初のp文字以内</text>
-    <text x="280" y="200" font-family="Inter, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#d32f2f">2. |y| > 0</text>
+    <text x="280" y="200" font-family="Inter, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#d32f2f">2. |y| &gt; 0</text>
     <text x="290" y="215" font-family="Inter, Helvetica, sans-serif" font-size="10" fill="#777">ループ部分は空でない</text>
     <text x="280" y="235" font-family="Inter, Helvetica, sans-serif" font-size="14" font-weight="bold" fill="#d32f2f">3. ∀i ≥ 0, xy<tspan dy="-3" font-size="11">i</tspan><tspan dy="3">z ∈ L</tspan></text>
     <text x="290" y="250" font-family="Inter, Helvetica, sans-serif" font-size="10" fill="#777">任意回数の繰り返しが可能</text>
@@ -69,7 +69,7 @@
     <text x="780" y="160" font-family="Inter, Helvetica, sans-serif" font-size="10" fill="#555">r₀, r₁, ..., rₚ</text>
     <text x="780" y="175" font-family="Inter, Helvetica, sans-serif" font-size="10" fill="#555">鳩の巣原理で</text>
     <text x="780" y="190" font-family="Inter, Helvetica, sans-serif" font-size="10" fill="#555">rⱼ = rₖ</text>
-    <text x="780" y="205" font-family="Inter, Helvetica, sans-serif" font-size="10" fill="#555">0 ≤ j < k ≤ p</text>
+    <text x="780" y="205" font-family="Inter, Helvetica, sans-serif" font-size="10" fill="#555">0 ≤ j &lt; k ≤ p</text>
     
     <!-- Decomposition -->
     <rect x="910" y="120" width="120" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>

--- a/docs/assets/images/diagrams/ch4_partial_recursive_functions.svg
+++ b/docs/assets/images/diagrams/ch4_partial_recursive_functions.svg
@@ -99,7 +99,7 @@
   <text x="400" y="475" class="diagram-text" style="fill: #d32f2f; font-weight: bold;">注意: 最小化により部分関数が生じる</text>
   <text x="400" y="495" class="diagram-text small-text">最小化演算子 μy[f(x̄,y) = 0] は、条件を満たすyが存在しない場合に未定義となる</text>
   <text x="400" y="510" class="diagram-text small-text">これにより、すべての値で定義されない「部分関数」が生成される</text>
-  <text x="400" y="525" class="diagram-text small-text">例: f(x) = μy[y > x ∧ y は偶数でない] → 常に未定義</text>
+  <text x="400" y="525" class="diagram-text small-text">例: f(x) = μy[y &gt; x ∧ y は偶数でない] → 常に未定義</text>
   
   <!-- Arrow from minimization to note -->
   <path d="M 500 340 Q 520 400 400 440" stroke="#d32f2f" stroke-width="2" 

--- a/docs/assets/images/diagrams/ch5_complexity_time_hierarchy.svg
+++ b/docs/assets/images/diagrams/ch5_complexity_time_hierarchy.svg
@@ -279,7 +279,7 @@
     
     <!-- Modern trends -->
     <text x="670" y="595" class="description">現代的傾向:</text>
-    <text x="680" y="610" class="class-notation" style="text-anchor:start">• ビッグデータ: nが巨大（n > 10⁹）</text>
+    <text x="680" y="610" class="class-notation" style="text-anchor:start">• ビッグデータ: nが巨大（n &gt; 10⁹）</text>
     <text x="1000" y="370" class="class-notation" style="text-anchor:start">• 近似アルゴリズム</text>
     <text x="1000" y="385" class="class-notation" style="text-anchor:start">• ランダム化アルゴリズム</text>
     <text x="1000" y="400" class="class-notation" style="text-anchor:start">• ヒューリスティック手法</text>

--- a/docs/assets/images/diagrams/ch6_master_theorem.svg
+++ b/docs/assets/images/diagrams/ch6_master_theorem.svg
@@ -91,7 +91,7 @@
     <rect x="550" y="60" width="300" height="80" class="problem-box" />
     <text x="700" y="85" class="box-title">分割統治の再帰式</text>
     <text x="700" y="105" class="formula">T(n) = aT(n/b) + f(n)</text>
-    <text x="700" y="125" class="condition">a ≥ 1, b > 1, f(n) ≥ 0</text>
+    <text x="700" y="125" class="condition">a ≥ 1, b &gt; 1, f(n) ≥ 0</text>
   </g>
   
   <!-- Comparison Step -->
@@ -186,7 +186,7 @@
     <text x="500" y="600" class="example-text">例3: Strassen行列積</text>
     <text x="500" y="615" class="formula" style="text-anchor:start">T(n) = 7T(n/2) + n²</text>
     <text x="500" y="630" class="example-text">a=7, b=2, f(n)=n²</text>
-    <text x="500" y="645" class="example-text">log₂(7) ≈ 2.807 > 2のため</text>
+    <text x="500" y="645" class="example-text">log₂(7) ≈ 2.807 &gt; 2のため</text>
     <text x="500" y="660" class="example-text">ケース1適用</text>
     <text x="500" y="675" class="formula" fill="#4caf50">T(n) = Θ(n^2.807)</text>
     <text x="500" y="690" class="explanation">標準O(n³)より高速</text>

--- a/docs/assets/images/diagrams/ch7_skip_list_structure.svg
+++ b/docs/assets/images/diagrams/ch7_skip_list_structure.svg
@@ -243,11 +243,11 @@
     <text x="300" y="345" class="title">検索例: 20を検索</text>
     
     <!-- Search steps -->
-    <text x="70" y="370" class="search-step">1. レベル3: -∞ → 17 (17 < 20) → +∞ (25 > 20) → 下へ</text>
+    <text x="70" y="370" class="search-step">1. レベル3: -∞ → 17 (17 &lt; 20) → +∞ (25 &gt; 20) → 下へ</text>
     
-    <text x="70" y="390" class="search-step">2. レベル2: 17 → 25 (25 > 20) → 下へ</text>
+    <text x="70" y="390" class="search-step">2. レベル2: 17 → 25 (25 &gt; 20) → 下へ</text>
     
-    <text x="70" y="410" class="search-step">3. レベル1: 17 → 25 (25 > 20) → 下へ</text>
+    <text x="70" y="410" class="search-step">3. レベル1: 17 → 25 (25 &gt; 20) → 下へ</text>
     
     <text x="70" y="430" class="search-step">4. レベル0: 17 → 20 を発見！</text>
     

--- a/docs/assets/images/diagrams/ch9_hoare_logic_inference_rules.svg
+++ b/docs/assets/images/diagrams/ch9_hoare_logic_inference_rules.svg
@@ -160,7 +160,7 @@
     <rect x="50" y="460" width="600" height="100" class="rule-box example-box" />
     <text x="350" y="480" class="rule-name">ループの例：0からn-1までの和</text>
     <text x="350" y="500" class="example-text">{n ≥ 0 ∧ i = 0 ∧ sum = 0}</text>
-    <text x="350" y="515" class="example-text">while i < n do (sum := sum + i; i := i + 1)</text>
+    <text x="350" y="515" class="example-text">while i &lt; n do (sum := sum + i; i := i + 1)</text>
     <text x="350" y="530" class="example-text">{sum = 0 + 1 + ... + (n-1)}</text>
     <text x="60" y="550" class="description">不変条件: sum = 0 + 1 + ... + (i-1) ∧ 0 ≤ i ≤ n</text>
   </g>

--- a/docs/assets/images/diagrams/ch9_hoare_logic_inference_system.svg
+++ b/docs/assets/images/diagrams/ch9_hoare_logic_inference_system.svg
@@ -167,12 +167,12 @@
     
     <text x="70" y="600" class="rule-title">プログラム:</text>
     <text x="80" y="620" class="rule-formula">max := a[0]; i := 1;</text>
-    <text x="80" y="635" class="rule-formula">while i < n do</text>
-    <text x="100" y="650" class="rule-formula">if a[i] > max then max := a[i];</text>
+    <text x="80" y="635" class="rule-formula">while i &lt; n do</text>
+    <text x="100" y="650" class="rule-formula">if a[i] &gt; max then max := a[i];</text>
     <text x="100" y="665" class="rule-formula">i := i + 1;</text>
     
     <text x="350" y="600" class="rule-title">仕様:</text>
-    <text x="360" y="620" class="rule-formula">事前条件: {n > 0}</text>
+    <text x="360" y="620" class="rule-formula">事前条件: {n &gt; 0}</text>
     <text x="360" y="635" class="rule-formula">事後条件: {max = max(a[0..n-1])}</text>
     
     <text x="70" y="690" class="rule-title">ループ不変条件:</text>


### PR DESCRIPTION
## 背景
`Release Artifacts` workflow の SVG→PDF 変換（rsvg-convert）が、SVG内テキストの未エスケープな比較演算子（`<` / `>`）によりXMLパースエラーで失敗していました。

## 変更内容
- 図版SVG内のテキストに含まれる ` < ` / ` > ` を、それぞれ `&lt;` / `&gt;` に置換（13ファイル、21箇所）

## 期待する効果
- rsvg-convert による SVG→PDF 変換が継続的に成功する
- SVGがXMLとして妥当になり、ブラウザ/ツール間の互換性が向上する
