### PR TITLE
fix: SVG内テキストの&をエスケープ

### DIFF
--- a/docs/assets/images/diagrams/ch12_lock_free_algorithms.svg
+++ b/docs/assets/images/diagrams/ch12_lock_free_algorithms.svg
@@ -207,7 +207,7 @@
     <!-- Step 3 -->
     <rect x="520" y="460" width="160" height="60" class="concept-box cas-operation" />
     <text x="600" y="480" class="method-title">3. CAS操作</text>
-    <text x="530" y="500" class="code-text">CAS(&Top, t, NewNode)</text>
+    <text x="530" y="500" class="code-text">CAS(&amp;Top, t, NewNode)</text>
     <text x="530" y="515" class="step-text">成功ならNewNodeが新Top</text>
     
     <!-- Arrows -->
@@ -232,7 +232,7 @@
     <!-- Step 3 -->
     <rect x="750" y="460" width="160" height="60" class="concept-box cas-operation" />
     <text x="830" y="480" class="method-title">3. CAS操作</text>
-    <text x="760" y="500" class="code-text">CAS(&Top, t, t.next)</text>
+    <text x="760" y="500" class="code-text">CAS(&amp;Top, t, t.next)</text>
     <text x="760" y="515" class="step-text">成功なら t を返却</text>
     
     <!-- Arrows -->

--- a/docs/assets/images/diagrams/ch5_np_completeness_reduction_chain.svg
+++ b/docs/assets/images/diagrams/ch5_np_completeness_reduction_chain.svg
@@ -310,7 +310,7 @@
     
     <text x="740" y="795" class="description">1971: Cook-Levin定理（SAT のNP完全性）</text>
     <text x="740" y="810" class="description">1972: Karpの21問題（基本的なNP完全問題群）</text>
-    <text x="740" y="825" class="description">1979: Garey & Johnson「Computers and Intractability」</text>
+    <text x="740" y="825" class="description">1979: Garey &amp; Johnson「Computers and Intractability」</text>
     <text x="740" y="840" class="description">1980s-: 近似困難性理論の発展</text>
     <text x="740" y="855" class="description">1990s-: PCP定理、近似限界の解明</text>
   </g>

--- a/docs/assets/images/diagrams/ch5_p_vs_np_structure.svg
+++ b/docs/assets/images/diagrams/ch5_p_vs_np_structure.svg
@@ -281,7 +281,7 @@
     
     <text x="70" y="735" class="description">1971: Cook-Levinの定理でSATのNP完全性が証明される</text>
     <text x="70" y="750" class="description">1972: Karpが21のNP完全問題を発見</text>
-    <text x="70" y="765" class="description">1979: Garey & Johnsonの「Computers and Intractability」出版</text>
+    <text x="70" y="765" class="description">1979: Garey &amp; Johnsonの「Computers and Intractability」出版</text>
     <text x="70" y="780" class="description">2000年: Clay数学研究所がP vs NPをミレニアム問題に指定（賞金100万ドル）</text>
     
     <text x="700" y="735" class="description">1990年代: 近似困難性理論の発展（PCP定理）</text>


### PR DESCRIPTION
## 背景
`Release Artifacts` workflow の SVG→PDF 変換（rsvg-convert）は、SVGがXMLとして妥当である必要があります。

一部図版でテキスト中に未エスケープの `&` が含まれており、環境によってはXMLパース/変換に失敗するリスクがあります。

## 変更内容
- 図版SVG内のテキストに含まれる `&` を `&amp;` に置換（3ファイル、4箇所）

