### PR TITLE
fix: Release PDF build (normalize Q\F etc)

### DIFF
--- a/python/tests/test_build_offline_book.py
+++ b/python/tests/test_build_offline_book.py
@@ -1,0 +1,35 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_build_offline_book():
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "build_offline_book.py"
+    spec = importlib.util.spec_from_file_location("build_offline_book", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalize_for_pdf_rewrites_set_difference_tokens():
+    m = _load_build_offline_book()
+    text = "ヒント: 初期分割 {F, Q\\F} から開始する。\nA \\ B も同様。\n"
+    out = m.normalize_for_pdf(text)
+    assert f"Q \u2216 F" in out
+    assert f"A \u2216 B" in out
+
+
+def test_normalize_for_pdf_does_not_touch_code_fences():
+    m = _load_build_offline_book()
+    text = "```\nQ\\F\n```\n"
+    out = m.normalize_for_pdf(text)
+    assert "Q\\F" in out
+
+
+def test_normalize_for_pdf_does_not_touch_latex_commands():
+    m = _load_build_offline_book()
+    text = "q\\in Q\nQ\\in F\nA\\cap B\n"
+    out = m.normalize_for_pdf(text)
+    assert out == text
+

--- a/scripts/build_offline_book.py
+++ b/scripts/build_offline_book.py
@@ -109,7 +109,11 @@ def preprocess_markdown(text: str) -> str:
     return text
 
 
-SET_DIFF_WORD_RE = re.compile(r"(?P<l>[A-Za-z0-9]+)\\\\{1,2}(?P<r>[A-Za-z0-9]+)")
+# `Q\F` のような表記（集合差/制限）を、PDF向けに安全な表記へ正規化するためのパターン。
+# `\in` などの LaTeX コマンド（右辺が小文字で始まる）には誤爆しないよう、左右とも大文字開始に限定する。
+SET_DIFF_TOKEN_RE = re.compile(
+    r"(?P<l>[A-Z][A-Za-z0-9]*)\s*\\{1,2}\s*(?P<r>[A-Z][A-Za-z0-9]*)"
+)
 
 
 def normalize_for_pdf(text: str) -> str:
@@ -135,11 +139,8 @@ def normalize_for_pdf(text: str) -> str:
             out.append(line)
             continue
 
-        # 1) "A \ B" のような空白付き（Markdown中で多い）を置換
-        line = line.replace(" \\ ", " ∖ ")
-
-        # 2) "Q\\F" / "V\\\\S" のような空白なし（単語間の演算子）を置換
-        line = SET_DIFF_WORD_RE.sub(r"\g<l> ∖ \g<r>", line)
+        # "A \\ B" / "A\\B" / "A\\\\B" を集合差記号へ正規化（PDF向け）。
+        line = SET_DIFF_TOKEN_RE.sub(r"\g<l> ∖ \g<r>", line)
 
         out.append(line)
 


### PR DESCRIPTION
Release Artifacts workflow（workflow_dispatch, Run 21325057167）が PDF 生成で失敗（\F など未定義制御綴）していたため、PDF向け正規化を修正します。

- `scripts/build_offline_book.py`: `Q\F` / `B\A` / `P\L` 等（1バックスラッシュ/空白あり/`\\`含む）を集合差記号へ置換
- `python/tests/test_build_offline_book.py`: 上記正規化の回帰テストを追加（コードフェンス・LaTeXコマンドは不変）