### PR TITLE
fix(docs): repair broken reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ tests/                     # テストファイル
 - [Book Publishing Template](https://github.com/itdojp/book-formatter)
 - [SVG図表作成ガイド](SVG_CREATION_GUIDE.md) - 学術品質の図表作成手法
 - [ITDO Inc. 公式サイト](https://itdo.jp)
-- [理論計算機科学参考文献](src/appendices/reading-list.md)
+- [理論計算機科学参考文献](src/appendices/g.md#参考文献代表例)
 
 ---
 


### PR DESCRIPTION
Issue #102 のリンク品質対応。

- README の参考文献リンクが存在しないファイル（src/appendices/reading-list.md）を参照していたため、実在する付録Gの参考文献セクションへリンク先を修正しました。
