### PR TITLE
ci: actions/setup-python を v6 に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         cache: 'npm'
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
         cache: 'pip'

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
- `.github/workflows/ci.yml` と `.github/workflows/release-artifacts.yml` の `actions/setup-python@v5` を `@v6` に更新
- 変更範囲はWorkflow参照の更新のみ

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102