### PR TITLE
fix: GitHub/Edit links on Pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -43,9 +43,10 @@ kramdown:
 repository: "itdojp/theoretical-computer-science-textbook"
 
 # 公開サイト向けリンク制御
-# NOTE: このリポジトリは Private のため、公開サイト上で GitHub リンクを出すと 404 になる。
-show_github_links: false
-show_edit_link: false
+# NOTE: 公開サイトに GitHub リンク / "Edit this page" を表示する場合は true にする。
+#       リポジトリが private の場合など、公開したくない場合は false にする。
+show_github_links: true
+show_edit_link: true
 
 # "Edit this page" の生成に必要な情報
 repository_branch: "main"

--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -126,7 +126,7 @@
         {% endif %}
 
         <div class="external-links">
-            {% if repo_url %}
+            {% if repo_url and site.show_github_links != false %}
             <a href="{{ repo_url }}" target="_blank" rel="noopener" class="external-link">GitHub</a>
             {% endif %}
             {% if site.contact.email %}
@@ -135,4 +135,3 @@
         </div>
     </div>
 </div>
-

--- a/docs/_layouts/book.html
+++ b/docs/_layouts/book.html
@@ -121,11 +121,13 @@
                     </svg>
                 </button>
                 
-                <a href="{{ repo_url | default: '#' }}" class="github-link" target="_blank" rel="noopener" aria-label="View on GitHub">
+                {% if repo_url and site.show_github_links != false %}
+                <a href="{{ repo_url }}" class="github-link" target="_blank" rel="noopener" aria-label="View on GitHub">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                     </svg>
                 </a>
+                {% endif %}
             </div>
         </header>
 
@@ -153,9 +155,19 @@
                 {% endif %}
 
                 <!-- Edit on GitHub -->
-                {% if repo_url and page.path %}
+                {% if repo_url and page.path and site.show_edit_link != false %}
+                {% assign repo_path_prefix = site.repository_path_prefix | default: '' %}
+                {% assign edit_path = page.path %}
+                {% if repo_path_prefix != '' %}
+                    {% assign prefix_with_slash = repo_path_prefix | append: '/' %}
+                    {% assign prefix_size = prefix_with_slash | size %}
+                    {% assign head = edit_path | slice: 0, prefix_size %}
+                    {% unless head == prefix_with_slash %}
+                        {% assign edit_path = prefix_with_slash | append: edit_path %}
+                    {% endunless %}
+                {% endif %}
                 <div class="edit-page">
-                    <a href="{{ repo_url }}/edit/{{ repo_branch }}/{{ page.path }}" 
+                    <a href="{{ repo_url }}/edit/{{ repo_branch }}/{{ edit_path }}" 
                        target="_blank" 
                        rel="noopener"
                        class="edit-link">


### PR DESCRIPTION
Fixes #206

- GitHub Pages が /docs からビルドされる構成でも、"Edit this page on GitHub" が実ファイル（docs/...）を指すように修正
- GitHub リンク / Edit link の表示は show_github_links / show_edit_link で制御（デフォルトは表示）
- repository_path_prefix（このリポジトリでは docs）を用いて edit URL を組み立て

確認観点
- トップ/各章/付録で GitHub リポジトリリンクが 200 で開く
- トップ/各章/付録で "Edit this page" が 200 で開く
