### PR TITLE
docs: align README + npm scripts with GitHub Pages Jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-deployed-green)](https://itdojp.github.io/theoretical-computer-science-textbook/)
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md)
-[![Jekyll](https://img.shields.io/badge/Jekyll-4.3-red)](https://jekyllrb.com/)
+[![Jekyll](https://img.shields.io/badge/Jekyll-3.10-red)](https://jekyllrb.com/)
 
 数学的基礎から始まり、計算理論、アルゴリズム、複雑性理論、そして最新の研究トピックまでを包括的にカバーする理論計算機科学の教科書。大学生、大学院生、研究者向けの体系的学習リソース。
 
@@ -94,9 +94,9 @@ bundle install
 npm install
 
 # ローカルサーバーを起動
-bundle exec jekyll serve --source docs
-# または
 npm run dev
+# または
+bundle exec jekyll serve --livereload --source docs --config docs/_config.yml --destination _site
 
 # ブラウザで http://localhost:4000 を開く
 ```
@@ -154,7 +154,7 @@ tests/                     # テストファイル
 
 ## 🔧 技術仕様
 
-- **静的サイトジェネレーター**: Jekyll 4.3
+- **静的サイトジェネレーター**: Jekyll 3.10.x（GitHub Pages: github-pages ~> 232）
 - **CSS フレームワーク**: カスタムCSS（Bootstrap非依存）
 - **数式レンダリング**: MathJax 3.0
 - **図表生成**: Mermaid 10

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "start": "bundle exec jekyll serve --livereload",
-    "build": "bundle exec jekyll build",
-    "build:gh-pages": "bundle exec jekyll build",
+    "dev": "bundle exec jekyll serve --livereload --source docs --config docs/_config.yml --destination _site",
+    "start": "npm run dev",
+    "build": "bundle exec jekyll build --source docs --config docs/_config.yml --destination _site",
+    "build:gh-pages": "npm run build",
     "preview": "npm run build && npx http-server _site -p 8080 --silent",
     "deploy": "gh-pages -d _site",
     "clean": "rm -rf _site .jekyll-cache",


### PR DESCRIPTION
関連: itdojp/it-engineer-knowledge-architecture#26

- README の Jekyll バージョン表記を GitHub Pages（github-pages ~> 232 / Jekyll 3.10.x）に合わせて修正
- `npm run dev` / `npm run build` が `docs/` を source として動作するように `package.json` を CI（Jekyll build --source docs ...）と整合

補足
- GitHub Pages は互換性の都合で Jekyll バージョンが固定されるため、README でもその前提を明示します。
