### PR TITLE
feat: use search-data.json for site-wide search

### DIFF
--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -36,49 +36,118 @@
             }
         } catch (_) {}
 
-        // Fallback: first path segment (best-effort).
-        try {
-            const seg = window.location.pathname.split('/').filter(Boolean)[0];
-            return seg ? '/' + seg : '';
-        } catch (_) {
-            return '';
+        // Fallback: use empty string so root-level deployments work correctly.
+        // If you need a different baseurl, ensure the script tag src includes it.
+        return '';
+    }
+
+    async function fetchWithTimeout(url, options, timeoutMs) {
+        if (!timeoutMs || timeoutMs <= 0) {
+            return await fetch(url, options);
         }
+
+        // Prefer AbortController when available to avoid hanging fetches.
+        if (typeof AbortController === 'function') {
+            const controller = new AbortController();
+            const timer = setTimeout(function() {
+                controller.abort();
+            }, timeoutMs);
+
+            try {
+                const finalOptions = Object.assign({}, options || {}, { signal: controller.signal });
+                const response = await fetch(url, finalOptions);
+                clearTimeout(timer);
+                return response;
+            } catch (err) {
+                clearTimeout(timer);
+                throw err;
+            }
+        }
+
+        // Fallback for older browsers: race with a timer (cannot abort the underlying request).
+        return await new Promise(function(resolve, reject) {
+            const timer = setTimeout(function() {
+                reject(new Error('fetch timeout'));
+            }, timeoutMs);
+
+            fetch(url, options).then(
+                function(response) {
+                    clearTimeout(timer);
+                    resolve(response);
+                },
+                function(err) {
+                    clearTimeout(timer);
+                    reject(err);
+                }
+            );
+        });
     }
 
     async function loadSearchData() {
-        const base = getSiteBasePath();
-        const url = `${base}/assets/search-data.json`;
-        const res = await fetch(url, { credentials: 'same-origin' });
-        if (!res.ok) {
-            throw new Error(`failed to fetch search-data.json: ${res.status}`);
-        }
-        const data = await res.json();
-        if (!data || !Array.isArray(data.items)) {
-            throw new Error('invalid search-data.json schema');
+        const bases = [];
+        bases.push(getSiteBasePath());
+        bases.push('');
+        // Best-effort fallback for unusual deployments where the script-derived baseurl isn't available.
+        try {
+            const seg = window.location.pathname.split('/').filter(Boolean)[0];
+            if (seg) bases.push('/' + seg);
+        } catch (_) {}
+
+        // Dedupe while preserving order.
+        const candidateBases = [];
+        for (let i = 0; i < bases.length; i++) {
+            if (candidateBases.indexOf(bases[i]) !== -1) continue;
+            candidateBases.push(bases[i]);
         }
 
-        // Page-level index (title + excerpt).
-        searchIndex = data.items
-            .map((item, idx) => {
-                const title = String(item.title || '').trim();
-                const content = String(item.excerpt || '').trim();
-                const pageUrl = String(item.url || '').trim();
-                return {
-                    id: `search-page-${idx}`,
-                    title,
-                    content,
-                    url: pageUrl,
-                    type: 'page'
-                };
-            })
-            .filter(it => it.title && it.url);
+        let lastError;
+        for (let i = 0; i < candidateBases.length; i++) {
+            const base = candidateBases[i];
+            const url = `${base}/assets/search-data.json`;
+
+            try {
+                const res = await fetchWithTimeout(url, { credentials: 'same-origin' }, 8000);
+                if (!res.ok) {
+                    lastError = new Error(`failed to fetch search-data.json (${url}): ${res.status}`);
+                    continue;
+                }
+                const data = await res.json();
+                if (!data || !Array.isArray(data.items)) {
+                    lastError = new Error(`invalid search-data.json schema (${url})`);
+                    continue;
+                }
+
+                // Page-level index (title + excerpt).
+                searchIndex = data.items
+                    .map((item, idx) => {
+                        if (!item || typeof item !== 'object') return null;
+                        const title = typeof item.title === 'string' ? item.title.trim() : '';
+                        const content = typeof item.excerpt === 'string' ? item.excerpt.trim() : '';
+                        const pageUrl = typeof item.url === 'string' ? item.url.trim() : '';
+                        if (!title || !pageUrl) return null;
+                        return {
+                            id: `search-page-${idx}`,
+                            title,
+                            content,
+                            url: pageUrl,
+                            type: 'page'
+                        };
+                    })
+                    .filter(Boolean);
+                return;
+            } catch (err) {
+                lastError = err;
+            }
+        }
+
+        throw lastError || new Error('failed to load search-data.json');
     }
     
     // Build search index from page content
     function buildSearchIndex() {
         searchIndex = [];
-        // In a real implementation, this would be generated at build time
-        // For now, we'll create a simple index from current page
+        // Fallback: when build-time generated search-data.json cannot be loaded via loadSearchData(),
+        // build a simple index from the current page content instead.
         const content = document.querySelector('.page-content');
         if (!content) return;
         
@@ -180,8 +249,37 @@
         try { el.scrollIntoView({ block: 'nearest' }); } catch (_) {}
     }
 
+    function getSafeNavigationHref(rawUrl) {
+        if (!rawUrl || typeof rawUrl !== 'string') return null;
+
+        try {
+            const origin =
+                window.location.origin ||
+                (window.location.protocol + '//' + window.location.host);
+            const basePath = getSiteBasePath();
+            const baseHref = origin + basePath + '/';
+            const parsedUrl = new URL(rawUrl, baseHref);
+
+            const protocol = parsedUrl.protocol;
+            if (protocol !== 'http:' && protocol !== 'https:') return null;
+            if (parsedUrl.origin !== origin) return null;
+
+            // If a baseurl is detected, restrict navigation to within it.
+            if (basePath) {
+                const pathname = parsedUrl.pathname || '';
+                if (!(pathname === basePath || pathname.startsWith(basePath + '/'))) return null;
+            }
+
+            return parsedUrl.href;
+        } catch (_) {
+            return null;
+        }
+    }
+
     function selectResultById(id) {
-        const result = searchIndex.find(item => item.id === id);
+        // Prefer the currently displayed results to avoid race conditions while the index is updating.
+        const result = (currentResults && currentResults.find(item => item.id === id)) ||
+            searchIndex.find(item => item.id === id);
         if (!result) return;
 
         hideResults();
@@ -190,8 +288,11 @@
         }
 
         if (result.url) {
-            window.location.href = result.url;
-            return;
+            const safeHref = getSafeNavigationHref(result.url);
+            if (safeHref) {
+                window.location.href = safeHref;
+                return;
+            }
         }
 
         if (!result.element) return;
@@ -289,9 +390,17 @@
         loadSearchData()
             .then(() => {
                 const q = searchInput.value.trim();
-                if (q && q.length >= 2) performSearch(q);
+                const isNavigating =
+                    searchResults &&
+                    searchResults.classList.contains('active') &&
+                    activeIndex >= 0;
+                if (q && q.length >= 2 && !isNavigating) performSearch(q);
             })
-            .catch(() => {});
+            .catch((error) => {
+                if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+                    console.warn('Search: failed to load search data', error);
+                }
+            });
         
         // Search input handler
         searchInput.addEventListener('input', (e) => {


### PR DESCRIPTION
関連: itdojp/it-engineer-knowledge-architecture#24

- `docs/assets/search-data.json`（ビルド時生成）を優先して読み込み、全ページ横断の検索を可能にします
- 読み込み失敗時（offline/404等）は従来どおり「表示中ページから動的に index を生成」へフォールバックします

実装メモ
- baseurl は script tag の `src`（`/assets/js/search.js` の前段）から導出し、GitHub Pages project site でも動作するようにしています
