### PR TITLE
chore(svg): normalize font-family stacks

### DIFF
--- a/docs/assets/images/diagrams/automata-hierarchy.svg
+++ b/docs/assets/images/diagrams/automata-hierarchy.svg
@@ -4,12 +4,12 @@
   <desc id="desc">有限オートマトン、プッシュダウンオートマトン、線形有界オートマトン、チューリング機械などの計算モデルと、対応する形式言語クラスの関係を示す概観図。</desc>
   <defs>
     <style>
-      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
-      .automaton-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #fff; }
-      .language-title { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; font-weight: bold; fill: #2c3e50; }
-      .text-content { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #2c3e50; }
-      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
-      .example-text { font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace; font-size: 10px; fill: #2c3e50; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .automaton-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: bold; fill: #fff; }
+      .language-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: bold; fill: #2c3e50; }
+      .text-content { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; fill: #2c3e50; }
+      .small-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; fill: #7f8c8d; }
+      .example-text { font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-size: 10px; fill: #2c3e50; }
       .dfa-box { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }
       .nfa-box { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
       .pda-box { fill: #f39c12; stroke: #e67e22; stroke-width: 2; }

--- a/docs/assets/images/diagrams/ch10_awgn_capacity_curve.svg
+++ b/docs/assets/images/diagrams/ch10_awgn_capacity_curve.svg
@@ -6,7 +6,7 @@
     <style>
       .axis { stroke: #222; stroke-width: 1.5; }
       .grid { stroke: #ddd; stroke-width: 1; }
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .curve { stroke: #2b8a3e; stroke-width: 3; fill: none; }
       .pt { fill: #1c7ed6; }
     </style>

--- a/docs/assets/images/diagrams/ch10_binary_entropy_curve.svg
+++ b/docs/assets/images/diagrams/ch10_binary_entropy_curve.svg
@@ -6,7 +6,7 @@
     <style>
       .axis { stroke: #222; stroke-width: 1.5; }
       .grid { stroke: #ddd; stroke-width: 1; }
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .curve { stroke: #1c7ed6; stroke-width: 3; fill: none; }
       .maxdot { fill: #e03131; }
     </style>

--- a/docs/assets/images/diagrams/ch10_channel_models_capacity.svg
+++ b/docs/assets/images/diagrams/ch10_channel_models_capacity.svg
@@ -26,7 +26,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -42,7 +42,7 @@
       }
       
       .model-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -50,7 +50,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 
@@ -58,7 +58,7 @@
       }
       
       .formula-center { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -66,7 +66,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -74,7 +74,7 @@
       }
       
       .parameter-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch10_huffman_coding_construction.svg
+++ b/docs/assets/images/diagrams/ch10_huffman_coding_construction.svg
@@ -24,7 +24,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -32,7 +32,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -40,7 +40,7 @@
       }
       
       .symbol-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -48,7 +48,7 @@
       }
       
       .probability { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -56,7 +56,7 @@
       }
       
       .code-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 
@@ -64,7 +64,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -72,7 +72,7 @@
       }
       
       .step-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch10_information_entropy_concepts.svg
+++ b/docs/assets/images/diagrams/ch10_information_entropy_concepts.svg
@@ -12,11 +12,11 @@
       .concept-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -24,7 +24,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -32,7 +32,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -41,7 +41,7 @@
       }
       
       .property-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -49,7 +49,7 @@
       }
       
       .example-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch10_information_theory_applications.svg
+++ b/docs/assets/images/diagrams/ch10_information_theory_applications.svg
@@ -18,7 +18,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -26,7 +26,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .app-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -42,7 +42,7 @@
       }
       
       .technique { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: start; 
@@ -50,7 +50,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -58,7 +58,7 @@
       }
       
       .example { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 8px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch11_aead_flow_overview.svg
+++ b/docs/assets/images/diagrams/ch11_aead_flow_overview.svg
@@ -4,7 +4,7 @@
   <desc id="desc">鍵・ノンス・追加認証データ（AD）・平文から暗号文と認証タグを生成し、復号側で検証する流れを示す。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .box { fill: #fff; stroke: #495057; stroke-width: 1.6; rx: 6px; }
       .panel { fill: #f8f9fa; stroke: #dee2e6; }
       .arrow { stroke: #212529; stroke-width: 1.6; marker-end: url(#m); fill: none; }

--- a/docs/assets/images/diagrams/ch11_cryptographic_systems_overview.svg
+++ b/docs/assets/images/diagrams/ch11_cryptographic_systems_overview.svg
@@ -13,11 +13,11 @@
       .concept-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -25,7 +25,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -33,7 +33,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 13px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -41,7 +41,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -49,7 +49,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch11_cryptography_basics.svg
+++ b/docs/assets/images/diagrams/ch11_cryptography_basics.svg
@@ -19,7 +19,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -27,7 +27,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -35,7 +35,7 @@
       }
       
       .crypto-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -43,7 +43,7 @@
       }
       
       .crypto-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -51,7 +51,7 @@
       }
       
       .math-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: start; 
@@ -59,7 +59,7 @@
       }
       
       .problem-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -67,7 +67,7 @@
       }
       
       .solution-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch11_ecb_pattern_leak_example.svg
+++ b/docs/assets/images/diagrams/ch11_ecb_pattern_leak_example.svg
@@ -4,7 +4,7 @@
   <desc id="desc">同一平文ブロックが同一暗号文ブロックになるため、画像の模様がそのまま暗号文に残る様子の模式図。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .panel { fill: #f8f9fa; stroke: #dee2e6; }
       .grid { fill: none; stroke: #ced4da; stroke-width: 1; }
       .blk { fill: #adb5bd; }

--- a/docs/assets/images/diagrams/ch11_rsa_algorithm_details.svg
+++ b/docs/assets/images/diagrams/ch11_rsa_algorithm_details.svg
@@ -13,11 +13,11 @@
       .step-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -25,7 +25,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -33,7 +33,7 @@
       }
       
       .step-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -41,7 +41,7 @@
       }
       
       .step-description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -49,7 +49,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -57,7 +57,7 @@
       }
       
       .example-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch11_rsa_cryptosystem.svg
+++ b/docs/assets/images/diagrams/ch11_rsa_cryptosystem.svg
@@ -18,7 +18,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -26,7 +26,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .step-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -42,7 +42,7 @@
       }
       
       .math-formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 
@@ -50,7 +50,7 @@
       }
       
       .explanation { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -58,7 +58,7 @@
       }
       
       .example-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -66,7 +66,7 @@
       }
       
       .warning-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch11_zero_knowledge_proofs.svg
+++ b/docs/assets/images/diagrams/ch11_zero_knowledge_proofs.svg
@@ -13,11 +13,11 @@
       .concept-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -25,7 +25,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -33,7 +33,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -41,7 +41,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -49,7 +49,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -57,7 +57,7 @@
       }
       
       .step-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch12_aba_problem_diagram.svg
+++ b/docs/assets/images/diagrams/ch12_aba_problem_diagram.svg
@@ -4,7 +4,7 @@
   <desc id="desc">CAS操作で参照中の値がA→B→Aと変化して検出できない問題の概念図。Hazard PointersやEpochベースの再利用抑止を示唆。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .panel { fill: #f8f9fa; stroke: #dee2e6; }
       .box { fill: #fff; stroke: #495057; stroke-width: 1.6; rx: 4px; }
       .arrow { stroke: #212529; stroke-width: 1.6; marker-end: url(#m); fill: none; }

--- a/docs/assets/images/diagrams/ch12_concurrent_computing_models.svg
+++ b/docs/assets/images/diagrams/ch12_concurrent_computing_models.svg
@@ -13,11 +13,11 @@
       .concept-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -25,7 +25,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -33,7 +33,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -41,7 +41,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -49,7 +49,7 @@
       }
       
       .process-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch12_deadlock_coffman_conditions.svg
+++ b/docs/assets/images/diagrams/ch12_deadlock_coffman_conditions.svg
@@ -4,7 +4,7 @@
   <desc id="desc">相互排他・占有待ち・不可奪取・循環待ちの4条件と、簡単な資源割当グラフの例示。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .panel { fill: #f8f9fa; stroke: #dee2e6; }
       .box { fill: #fff; stroke: #495057; stroke-width: 1.6; rx: 4px; }
       .edge { stroke: #495057; stroke-width: 1.6; marker-end: url(#m); fill: none; }

--- a/docs/assets/images/diagrams/ch12_hb_relations_timeline.svg
+++ b/docs/assets/images/diagrams/ch12_hb_relations_timeline.svg
@@ -4,7 +4,7 @@
   <desc id="desc">2スレッドの操作列と同期イベント（ロック/アンロック）による可視性の順序付け（HB）を示す図。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .thread { stroke: #868e96; stroke-width: 2; }
       .event { fill: #fff; stroke: #495057; stroke-width: 1.6; rx: 4px; }
       .sync { fill: #e7f5ff; stroke: #228be6; }

--- a/docs/assets/images/diagrams/ch12_lock_free_algorithms.svg
+++ b/docs/assets/images/diagrams/ch12_lock_free_algorithms.svg
@@ -13,11 +13,11 @@
       .concept-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -25,7 +25,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -33,7 +33,7 @@
       }
       
       .method-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -41,7 +41,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -49,7 +49,7 @@
       }
       
       .code-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -57,7 +57,7 @@
       }
       
       .step-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch12_petri_nets_modeling.svg
+++ b/docs/assets/images/diagrams/ch12_petri_nets_modeling.svg
@@ -13,11 +13,11 @@
       .concept-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -25,7 +25,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -33,7 +33,7 @@
       }
       
       .element-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -41,7 +41,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -49,7 +49,7 @@
       }
       
       .label-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -57,7 +57,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch1_graph_examples_comprehensive.svg
+++ b/docs/assets/images/diagrams/ch1_graph_examples_comprehensive.svg
@@ -5,10 +5,10 @@
   
   <defs>
     <style>
-      .title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 600; fill: #1a1a1a; }
-      .section-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 16px; font-weight: 600; fill: #333; }
-      .subtitle { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 500; fill: #555; }
-      .label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 500; fill: #1a1a1a; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 600; fill: #1a1a1a; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: #333; }
+      .subtitle { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 500; fill: #555; }
+      .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: #1a1a1a; }
       .vertex { fill: #e3f2fd; stroke: #2563eb; stroke-width: 2; }
       .vertex-tree { fill: #fff3e0; stroke: #f57c00; stroke-width: 2; }
       .vertex-dag { fill: #f3e5f5; stroke: #7b1fa2; stroke-width: 2; }

--- a/docs/assets/images/diagrams/ch1_graph_theory_basics.svg
+++ b/docs/assets/images/diagrams/ch1_graph_theory_basics.svg
@@ -11,7 +11,7 @@
       .loop-edge { stroke: #ff9800; stroke-width: 2px; fill: none; }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -19,7 +19,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -27,7 +27,7 @@
       }
       
       .vertex-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -36,7 +36,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -44,7 +44,7 @@
       }
       
       .graph-type { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch1_rational_enumeration_cantor.svg
+++ b/docs/assets/images/diagrams/ch1_rational_enumeration_cantor.svg
@@ -5,12 +5,12 @@
   
   <defs>
     <style>
-      .title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 16px; font-weight: 600; fill: #1a1a1a; }
-      .subtitle { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 500; fill: #333; }
-      .fraction { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 500; fill: #2563eb; }
-      .order { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; font-weight: 400; fill: #dc2626; }
-      .label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 11px; font-weight: 400; fill: #555; }
-      .skip { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 11px; font-weight: 400; fill: #666; text-decoration: line-through; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: #1a1a1a; }
+      .subtitle { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 500; fill: #333; }
+      .fraction { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: #2563eb; }
+      .order { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: #dc2626; }
+      .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; font-weight: 400; fill: #555; }
+      .skip { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; font-weight: 400; fill: #666; text-decoration: line-through; }
       .node { fill: #e3f2fd; stroke: #2563eb; stroke-width: 2; }
       .skip-node { fill: #f5f5f5; stroke: #999; stroke-width: 2; stroke-dasharray: 3,3; }
       .arrow { fill: none; stroke: #2563eb; stroke-width: 2; marker-end: url(#arrowhead); }

--- a/docs/assets/images/diagrams/ch1_rational_number_enumeration.svg
+++ b/docs/assets/images/diagrams/ch1_rational_number_enumeration.svg
@@ -10,7 +10,7 @@
       .path-arrow { stroke: #ff9800; stroke-width: 3px; fill: none; marker-end: url(#path-arrowhead); }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -18,7 +18,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -26,7 +26,7 @@
       }
       
       .fraction-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 12px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .order-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -42,7 +42,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -50,7 +50,7 @@
       }
       
       .sum-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch1_set_operations_detailed.svg
+++ b/docs/assets/images/diagrams/ch1_set_operations_detailed.svg
@@ -5,10 +5,10 @@
   
   <defs>
     <style>
-      .title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 16px; font-weight: 600; fill: #1a1a1a; }
-      .subtitle { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 500; fill: #333; }
-      .label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 400; fill: #555; }
-      .operation { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #2563eb; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: #1a1a1a; }
+      .subtitle { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 500; fill: #333; }
+      .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 400; fill: #555; }
+      .operation { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #2563eb; }
       .set-a { fill: #3b82f6; fill-opacity: 0.3; stroke: #2563eb; stroke-width: 2; }
       .set-b { fill: #ef4444; fill-opacity: 0.3; stroke: #dc2626; stroke-width: 2; }
       .result-union { fill: #e3f2fd; stroke: #1976d2; stroke-width: 2; }

--- a/docs/assets/images/diagrams/ch1_set_operations_visualization.svg
+++ b/docs/assets/images/diagrams/ch1_set_operations_visualization.svg
@@ -10,7 +10,7 @@
       .intersection-area { fill: rgba(156, 39, 176, 0.4); stroke: #9c27b0; stroke-width: 3px; }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -18,7 +18,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -26,7 +26,7 @@
       }
       
       .set-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 16px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 400; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch1_theoretical_cs_overview.svg
+++ b/docs/assets/images/diagrams/ch1_theoretical_cs_overview.svg
@@ -12,7 +12,7 @@
       .chapter-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .chapter-title { 

--- a/docs/assets/images/diagrams/ch2_computability_concepts.svg
+++ b/docs/assets/images/diagrams/ch2_computability_concepts.svg
@@ -12,11 +12,11 @@
       .concept-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -24,7 +24,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -32,7 +32,7 @@
       }
       
       .concept-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 13px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -40,7 +40,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -48,7 +48,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch2_computability_hierarchy.svg
+++ b/docs/assets/images/diagrams/ch2_computability_hierarchy.svg
@@ -9,10 +9,10 @@
       .thesis-box { fill: #fff3e0; stroke: #f57c00; stroke-width: 2; rx: 8; }
       .decidable-box { fill: #e3f2fd; stroke: #1976d2; stroke-width: 2; rx: 8; }
       .undecidable-box { fill: #ffebee; stroke: #d32f2f; stroke-width: 2; rx: 8; }
-      .title-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
-      .section-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #2c3e50; text-anchor: middle; }
-      .main-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 500; fill: #2c3e50; text-anchor: middle; }
-      .detail-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; fill: #495057; text-anchor: middle; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #2c3e50; text-anchor: middle; }
+      .main-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: #2c3e50; text-anchor: middle; }
+      .detail-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; fill: #495057; text-anchor: middle; }
       .connection-line { stroke: #666; stroke-width: 1.5; fill: none; }
     </style>
   </defs>

--- a/docs/assets/images/diagrams/ch2_decidability_hierarchy.svg
+++ b/docs/assets/images/diagrams/ch2_decidability_hierarchy.svg
@@ -15,10 +15,10 @@
       .atm-box { fill: #ffe0b2; stroke: #ff9800; stroke-width: 2; rx: 8; }
       .reduction-box { fill: #f3e5f5; stroke: #9c27b0; stroke-width: 2; rx: 8; }
       
-      .title-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
-      .section-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #2c3e50; text-anchor: middle; }
-      .main-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 500; fill: #2c3e50; text-anchor: middle; }
-      .detail-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; fill: #495057; text-anchor: middle; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #2c3e50; text-anchor: middle; }
+      .main-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: #2c3e50; text-anchor: middle; }
+      .detail-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; fill: #495057; text-anchor: middle; }
       .inclusion-arrow { stroke: #666; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
       .connection-line { stroke: #666; stroke-width: 1; fill: none; }
     </style>

--- a/docs/assets/images/diagrams/ch2_diagonalization_undecidability.svg
+++ b/docs/assets/images/diagrams/ch2_diagonalization_undecidability.svg
@@ -11,11 +11,11 @@
       .hierarchy-box { fill: #e3f2fd; stroke: #1976d2; stroke-width: 2; rx: 8; }
       .contradiction-box { fill: #ffebee; stroke: #d32f2f; stroke-width: 3; rx: 8; }
       
-      .title-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
-      .section-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #2c3e50; text-anchor: middle; }
-      .main-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 500; text-anchor: middle; }
-      .detail-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; text-anchor: middle; }
-      .formula-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 11px; font-weight: 500; text-anchor: middle; font-style: italic; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #2c3e50; text-anchor: middle; }
+      .main-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; text-anchor: middle; }
+      .detail-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; text-anchor: middle; }
+      .formula-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; font-weight: 500; text-anchor: middle; font-style: italic; }
       .reduction-arrow { stroke: #9c27b0; stroke-width: 2; fill: none; marker-end: url(#purplearrow); }
       .implication-arrow { stroke: #666; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
     </style>

--- a/docs/assets/images/diagrams/ch2_equivalent_computation_models.svg
+++ b/docs/assets/images/diagrams/ch2_equivalent_computation_models.svg
@@ -12,11 +12,11 @@
       .model-box { 
         rx: 8px; 
         ry: 8px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -24,7 +24,7 @@
       }
       
       .model-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -32,7 +32,7 @@
       }
       
       .year-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -40,7 +40,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch2_equivalent_computation_models_1930s.svg
+++ b/docs/assets/images/diagrams/ch2_equivalent_computation_models_1930s.svg
@@ -9,11 +9,11 @@
       .lambda-box { fill: #fff3e0; stroke: #f57c00; stroke-width: 2; rx: 12; }
       .recursive-box { fill: #e8f5e8; stroke: #2e7d32; stroke-width: 2; rx: 12; }
       .post-box { fill: #f3e5f5; stroke: #7b1fa2; stroke-width: 2; rx: 12; }
-      .title-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
-      .model-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; text-anchor: middle; }
-      .model-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; text-anchor: middle; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
+      .model-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; text-anchor: middle; }
+      .model-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; text-anchor: middle; }
       .equivalence-arrow { stroke: #666; stroke-width: 2; fill: none; marker-end: url(#arrowhead); stroke-dasharray: 5,3; }
-      .equivalence-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 11px; font-weight: 500; fill: #666; text-anchor: middle; }
+      .equivalence-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; font-weight: 500; fill: #666; text-anchor: middle; }
     </style>
     
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">

--- a/docs/assets/images/diagrams/ch2_turing_machine_components.svg
+++ b/docs/assets/images/diagrams/ch2_turing_machine_components.svg
@@ -21,7 +21,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -29,7 +29,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -37,7 +37,7 @@
       }
       
       .component-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 13px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -45,7 +45,7 @@
       }
       
       .component-desc { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -53,7 +53,7 @@
       }
       
       .formal-notation {
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 15px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -67,7 +67,7 @@
       }
       
       .tape-text {
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 14px;
         font-weight: 600;
         text-anchor: middle;

--- a/docs/assets/images/diagrams/ch2_turing_machine_configuration.svg
+++ b/docs/assets/images/diagrams/ch2_turing_machine_configuration.svg
@@ -7,16 +7,16 @@
     <style>
       .tape-cell { fill: #ffffff; stroke: #2c3e50; stroke-width: 1.5; }
       .tape-cell-active { fill: #ffeb3b; stroke: #2c3e50; stroke-width: 2; }
-      .tape-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 16px; font-weight: 600; text-anchor: middle; fill: #2c3e50; }
+      .tape-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; text-anchor: middle; fill: #2c3e50; }
       .control-box { fill: #e3f2fd; stroke: #1976d2; stroke-width: 2; rx: 8; }
-      .control-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 500; text-anchor: middle; fill: #1976d2; }
+      .control-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 500; text-anchor: middle; fill: #1976d2; }
       .head-box { fill: #fff3e0; stroke: #f57c00; stroke-width: 2; rx: 6; }
-      .head-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 500; text-anchor: middle; fill: #f57c00; }
+      .head-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; text-anchor: middle; fill: #f57c00; }
       .arrow { stroke: #666; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
       .dashed-arrow { stroke: #666; stroke-width: 2; fill: none; stroke-dasharray: 5,3; marker-end: url(#arrowhead); }
       .info-box { fill: #f8f9fa; stroke: #dee2e6; stroke-width: 1; rx: 6; }
-      .info-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; fill: #495057; }
-      .section-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 16px; font-weight: 600; fill: #2c3e50; }
+      .info-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; fill: #495057; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: #2c3e50; }
     </style>
     
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">

--- a/docs/assets/images/diagrams/ch2_turing_machine_structure.svg
+++ b/docs/assets/images/diagrams/ch2_turing_machine_structure.svg
@@ -11,7 +11,7 @@
       .connection { stroke: #666; stroke-width: 2px; stroke-dasharray: 6,3; fill: none; }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -19,7 +19,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -27,7 +27,7 @@
       }
       
       .tape-symbol { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 16px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -36,7 +36,7 @@
       }
       
       .state-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -45,7 +45,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -53,7 +53,7 @@
       }
       
       .component-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch2_turing_machine_variants.svg
+++ b/docs/assets/images/diagrams/ch2_turing_machine_variants.svg
@@ -11,13 +11,13 @@
       .standard-box { fill: #e8f5e8; stroke: #2e7d32; stroke-width: 2; rx: 8; }
       .equivalence-box { fill: #ffe0b2; stroke: #ff9800; stroke-width: 2; rx: 8; }
       
-      .title-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
-      .section-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #2c3e50; text-anchor: middle; }
-      .main-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 500; text-anchor: middle; }
-      .detail-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; text-anchor: middle; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #2c3e50; text-anchor: middle; }
+      .main-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; text-anchor: middle; }
+      .detail-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; text-anchor: middle; }
       .simulate-arrow { stroke: #666; stroke-width: 2; fill: none; marker-end: url(#arrowhead); stroke-dasharray: 5,3; }
       .equivalence-arrow { stroke: #2e7d32; stroke-width: 3; fill: none; marker-end: url(#greenarrow); }
-      .simulate-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; font-weight: 500; fill: #666; text-anchor: middle; }
+      .simulate-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 500; fill: #666; text-anchor: middle; }
     </style>
     
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">

--- a/docs/assets/images/diagrams/ch2_universal_turing_machine.svg
+++ b/docs/assets/images/diagrams/ch2_universal_turing_machine.svg
@@ -11,10 +11,10 @@
       .applications-box { fill: #f3e5f5; stroke: #7b1fa2; stroke-width: 2; rx: 8; }
       .selfref-box { fill: #ffebee; stroke: #d32f2f; stroke-width: 2; rx: 8; }
       
-      .title-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
-      .section-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #2c3e50; text-anchor: middle; }
-      .main-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 500; text-anchor: middle; }
-      .detail-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; text-anchor: middle; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 700; fill: #2c3e50; text-anchor: middle; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #2c3e50; text-anchor: middle; }
+      .main-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; text-anchor: middle; }
+      .detail-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; text-anchor: middle; }
       .flow-arrow { stroke: #666; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
       .connection-line { stroke: #adb5bd; stroke-width: 1; fill: none; stroke-dasharray: 3,2; }
     </style>

--- a/docs/assets/images/diagrams/ch3_context_free_language_properties.svg
+++ b/docs/assets/images/diagrams/ch3_context_free_language_properties.svg
@@ -7,7 +7,7 @@
   <rect width="1200" height="900" fill="#f8f9fa"/>
   
   <!-- Title -->
-  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="24" font-weight="bold" fill="#1a1a1a">文脈自由言語の性質と限界</text>
+  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="24" font-weight="bold" fill="#1a1a1a">文脈自由言語の性質と限界</text>
   
   <!-- Main Container -->
   <rect x="20" y="50" width="1160" height="830" fill="none" stroke="#e1e5e9" stroke-width="2" rx="10"/>
@@ -15,163 +15,163 @@
   <!-- Section 1: Closure Properties -->
   <g id="closure-properties">
     <rect x="40" y="80" width="560" height="200" fill="#e8f5e8" stroke="#388e3c" stroke-width="2" rx="8"/>
-    <text x="320" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#388e3c">閉包性</text>
+    <text x="320" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#388e3c">閉包性</text>
     
     <!-- Closed Operations -->
     <rect x="60" y="120" width="240" height="140" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="180" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">閉じている演算</text>
-    <text x="70" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 和集合 ∪</text>
-    <text x="80" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">L₁ ∪ L₂が文脈自由</text>
-    <text x="70" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 連結 ・</text>
-    <text x="80" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">L₁L₂が文脈自由</text>
-    <text x="70" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• クリーネ閉包 *</text>
-    <text x="80" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">L*が文脈自由</text>
-    <text x="70" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 正規言語との積集合 ∩</text>
+    <text x="180" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">閉じている演算</text>
+    <text x="70" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 和集合 ∪</text>
+    <text x="80" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">L₁ ∪ L₂が文脈自由</text>
+    <text x="70" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 連結 ・</text>
+    <text x="80" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">L₁L₂が文脈自由</text>
+    <text x="70" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• クリーネ閉包 *</text>
+    <text x="80" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">L*が文脈自由</text>
+    <text x="70" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 正規言語との積集合 ∩</text>
     
     <!-- Not Closed Operations -->
     <rect x="320" y="120" width="260" height="140" fill="#ffffff" stroke="#d32f2f" stroke-width="1" rx="4"/>
-    <text x="450" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#d32f2f">閉じていない演算</text>
-    <text x="330" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 積集合 ∩</text>
-    <text x="340" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">CFL ∩ CFL ⊄ CFL</text>
-    <text x="330" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 補集合 ¯</text>
-    <text x="340" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">L̄ が非文脈自由の場合あり</text>
-    <text x="330" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 差集合 \</text>
-    <text x="340" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">L₁ \ L₂ が非文脈自由の場合あり</text>
-    <text x="330" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 相補: L₁ᶜ ∩ L₂ᶜ</text>
+    <text x="450" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#d32f2f">閉じていない演算</text>
+    <text x="330" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 積集合 ∩</text>
+    <text x="340" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">CFL ∩ CFL ⊄ CFL</text>
+    <text x="330" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 補集合 ¯</text>
+    <text x="340" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">L̄ が非文脈自由の場合あり</text>
+    <text x="330" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 差集合 \</text>
+    <text x="340" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">L₁ \ L₂ が非文脈自由の場合あり</text>
+    <text x="330" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 相補: L₁ᶜ ∩ L₂ᶜ</text>
     
     <!-- Counter Example -->
     <rect x="40" y="300" width="560" height="120" fill="#ffebee" stroke="#d32f2f" stroke-width="2" rx="8"/>
-    <text x="320" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="16" font-weight="bold" fill="#d32f2f">反例</text>
+    <text x="320" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="16" font-weight="bold" fill="#d32f2f">反例</text>
     
-    <text x="60" y="350" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">L₁ = {aⁿbⁿcᵐ | n,m ≥ 0}　L₂ = {aᵐbⁿcⁿ | n,m ≥ 0}</text>
-    <text x="60" y="370" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">L₁, L₂はそれぞれ文脈自由言語だが:</text>
-    <text x="60" y="385" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#d32f2f">L₁ ∩ L₂ = {aⁿbⁿcⁿ | n ≥ 0}は非文脈自由</text>
-    <text x="60" y="400" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">∴ 文脈自由言語は積集合に関して閉じていない</text>
+    <text x="60" y="350" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">L₁ = {aⁿbⁿcᵐ | n,m ≥ 0}　L₂ = {aᵐbⁿcⁿ | n,m ≥ 0}</text>
+    <text x="60" y="370" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">L₁, L₂はそれぞれ文脈自由言語だが:</text>
+    <text x="60" y="385" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#d32f2f">L₁ ∩ L₂ = {aⁿbⁿcⁿ | n ≥ 0}は非文脈自由</text>
+    <text x="60" y="400" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">∴ 文脈自由言語は積集合に関して閉じていない</text>
   </g>
   
   <!-- Section 2: Decision Problems -->
   <g id="decision-problems">
     <rect x="620" y="80" width="540" height="340" fill="#e3f2fd" stroke="#1976d2" stroke-width="2" rx="8"/>
-    <text x="890" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#1976d2">決定問題</text>
+    <text x="890" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#1976d2">決定問題</text>
     
     <!-- Decidable Problems -->
     <rect x="640" y="120" width="240" height="180" fill="#ffffff" stroke="#4caf50" stroke-width="1" rx="4"/>
-    <text x="760" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#4caf50">決定可能問題</text>
-    <text x="650" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 所属問題: w ∈ L?</text>
-    <text x="660" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">CYKアルゴリズム O(n³|G|)</text>
-    <text x="650" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 空問題: L = ∅?</text>
-    <text x="660" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">到達可能変数の解析</text>
-    <text x="650" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 有限性問題: Lは有限?</text>
-    <text x="660" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">Pumping長の解析</text>
-    <text x="650" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 単語生成問題</text>
-    <text x="650" y="265" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 長さ制限問題</text>
-    <text x="650" y="280" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 正規性問題（一部）</text>
+    <text x="760" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#4caf50">決定可能問題</text>
+    <text x="650" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 所属問題: w ∈ L?</text>
+    <text x="660" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">CYKアルゴリズム O(n³|G|)</text>
+    <text x="650" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 空問題: L = ∅?</text>
+    <text x="660" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">到達可能変数の解析</text>
+    <text x="650" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 有限性問題: Lは有限?</text>
+    <text x="660" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">Pumping長の解析</text>
+    <text x="650" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 単語生成問題</text>
+    <text x="650" y="265" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 長さ制限問題</text>
+    <text x="650" y="280" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 正規性問題（一部）</text>
     
     <!-- Undecidable Problems -->
     <rect x="900" y="120" width="240" height="180" fill="#ffffff" stroke="#d32f2f" stroke-width="1" rx="4"/>
-    <text x="1020" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#d32f2f">決定不能問題</text>
-    <text x="910" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 等価性問題: L₁ = L₂?</text>
-    <text x="920" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">Rice定理の系</text>
-    <text x="910" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 包含問題: L₁ ⊆ L₂?</text>
-    <text x="920" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">等価性問題に帰着</text>
-    <text x="910" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 曖昧性問題: CFGは曖昧?</text>
-    <text x="920" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">一般には決定不能</text>
-    <text x="910" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 交集合空問題</text>
-    <text x="910" y="265" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 全言語問題</text>
-    <text x="910" y="280" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 文脈依存性問題</text>
+    <text x="1020" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#d32f2f">決定不能問題</text>
+    <text x="910" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 等価性問題: L₁ = L₂?</text>
+    <text x="920" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">Rice定理の系</text>
+    <text x="910" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 包含問題: L₁ ⊆ L₂?</text>
+    <text x="920" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">等価性問題に帰着</text>
+    <text x="910" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 曖昧性問題: CFGは曖昧?</text>
+    <text x="920" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">一般には決定不能</text>
+    <text x="910" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 交集合空問題</text>
+    <text x="910" y="265" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 全言語問題</text>
+    <text x="910" y="280" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 文脈依存性問題</text>
     
     <!-- CYK Algorithm -->
     <rect x="640" y="320" width="500" height="80" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="890" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">構文解析アルゴリズム</text>
-    <text x="650" y="360" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#333">CYK(Cocke-Younger-Kasami)アルゴリズム:</text>
-    <text x="650" y="375" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• CNF（Chomsky標準形）を使用　• 動的計画法によるボトムアップ解析</text>
-    <text x="650" y="390" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• O(n³)時間計算量　• 全ての可能な導出を表形式で管理</text>
+    <text x="890" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">構文解析アルゴリズム</text>
+    <text x="650" y="360" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#333">CYK(Cocke-Younger-Kasami)アルゴリズム:</text>
+    <text x="650" y="375" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• CNF（Chomsky標準形）を使用　• 動的計画法によるボトムアップ解析</text>
+    <text x="650" y="390" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• O(n³)時間計算量　• 全ての可能な導出を表形式で管理</text>
   </g>
   
   <!-- Section 3: Deterministic Context-Free Languages -->
   <g id="dcfl">
     <rect x="40" y="440" width="1120" height="200" fill="#fff3e0" stroke="#f57c00" stroke-width="2" rx="8"/>
-    <text x="600" y="465" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#f57c00">決定性文脈自由言語</text>
+    <text x="600" y="465" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#f57c00">決定性文脈自由言語</text>
     
     <!-- DPDA -->
     <rect x="60" y="480" width="250" height="140" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="185" y="500" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">決定性PDA(DPDA)</text>
-    <text x="70" y="520" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 各構成で高々一つの遷移</text>
-    <text x="70" y="535" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 受理条件の制約:</text>
-    <text x="80" y="550" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">最終状態 OR 空スタック</text>
-    <text x="70" y="565" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• LR(k)文法と関連</text>
-    <text x="70" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 効率的な構文解析</text>
-    <text x="70" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 実時間処理可能</text>
-    <text x="70" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 曖昧性なし</text>
+    <text x="185" y="500" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">決定性PDA(DPDA)</text>
+    <text x="70" y="520" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 各構成で高々一つの遷移</text>
+    <text x="70" y="535" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 受理条件の制約:</text>
+    <text x="80" y="550" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">最終状態 OR 空スタック</text>
+    <text x="70" y="565" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• LR(k)文法と関連</text>
+    <text x="70" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 効率的な構文解析</text>
+    <text x="70" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 実時間処理可能</text>
+    <text x="70" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 曖昧性なし</text>
     
     <!-- DCFL Properties -->
     <rect x="330" y="480" width="260" height="140" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="460" y="500" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">決定性文脈自由言語(DCFL)</text>
-    <text x="340" y="520" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• DPDAで受理される言語</text>
-    <text x="340" y="535" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#d32f2f">DCFL ⊊ CFL (真部分集合)</text>
-    <text x="340" y="550" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 補集合に関して閉じている</text>
-    <text x="340" y="565" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 和集合に関して閉じていない</text>
-    <text x="340" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• LR(k), LL(k)言語</text>
-    <text x="340" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 線形時間認識可能</text>
-    <text x="340" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• プリフィックス性</text>
+    <text x="460" y="500" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">決定性文脈自由言語(DCFL)</text>
+    <text x="340" y="520" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• DPDAで受理される言語</text>
+    <text x="340" y="535" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#d32f2f">DCFL ⊊ CFL (真部分集合)</text>
+    <text x="340" y="550" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 補集合に関して閉じている</text>
+    <text x="340" y="565" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 和集合に関して閉じていない</text>
+    <text x="340" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• LR(k), LL(k)言語</text>
+    <text x="340" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 線形時間認識可能</text>
+    <text x="340" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• プリフィックス性</text>
     
     <!-- Applications -->
     <rect x="610" y="480" width="220" height="140" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="720" y="500" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">実用的応用</text>
-    <text x="620" y="520" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• プログラミング言語:</text>
-    <text x="630" y="535" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">C, Pascal, Java等</text>
-    <text x="620" y="550" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• LRパーサ:</text>
-    <text x="630" y="565" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">LALR(1), SLR(1)</text>
-    <text x="620" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• コンパイラ設計:</text>
-    <text x="630" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">yacc, bison</text>
-    <text x="620" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 構造化データ解析</text>
+    <text x="720" y="500" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">実用的応用</text>
+    <text x="620" y="520" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• プログラミング言語:</text>
+    <text x="630" y="535" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">C, Pascal, Java等</text>
+    <text x="620" y="550" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• LRパーサ:</text>
+    <text x="630" y="565" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">LALR(1), SLR(1)</text>
+    <text x="620" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• コンパイラ設計:</text>
+    <text x="630" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">yacc, bison</text>
+    <text x="620" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 構造化データ解析</text>
     
     <!-- Examples -->
     <rect x="850" y="480" width="290" height="140" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="995" y="500" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">例</text>
-    <text x="860" y="520" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">DCFL: {aⁿbⁿ | n ≥ 0}</text>
-    <text x="870" y="535" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">決定的に処理可能</text>
-    <text x="860" y="550" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">CFL \ DCFL: {wwᴿ | w ∈ {a,b}*}</text>
-    <text x="870" y="565" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">回文は非決定性が必要</text>
-    <text x="860" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">非DCFL: {aⁱbʲcᵏ | i=j または j=k}</text>
-    <text x="870" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">選択が非決定的</text>
+    <text x="995" y="500" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">例</text>
+    <text x="860" y="520" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">DCFL: {aⁿbⁿ | n ≥ 0}</text>
+    <text x="870" y="535" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">決定的に処理可能</text>
+    <text x="860" y="550" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">CFL \ DCFL: {wwᴿ | w ∈ {a,b}*}</text>
+    <text x="870" y="565" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">回文は非決定性が必要</text>
+    <text x="860" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">非DCFL: {aⁱbʲcᵏ | i=j または j=k}</text>
+    <text x="870" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">選択が非決定的</text>
   </g>
   
   <!-- Section 4: Language Class Hierarchy -->
   <g id="language-hierarchy">
     <rect x="40" y="660" width="1120" height="200" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="2" rx="8"/>
-    <text x="600" y="685" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#7b1fa2">言語クラスの階層</text>
+    <text x="600" y="685" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#7b1fa2">言語クラスの階層</text>
     
     <!-- Chomsky Hierarchy -->
     <rect x="60" y="700" width="340" height="140" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="230" y="720" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">チョムスキーの階層</text>
-    <text x="230" y="745" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#333">正規言語 ⊂ DCFL ⊂ 文脈自由言語</text>
-    <text x="230" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#333">⊂ 文脈依存言語 ⊂ 再帰的可算言語</text>
-    <text x="70" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">各レベル:</text>
-    <text x="70" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">Type 3 → Type 2 → Type 1 → Type 0</text>
-    <text x="70" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">生成規則の制約が段階的に緩和</text>
-    <text x="70" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">表現力の厳密な包含関係</text>
+    <text x="230" y="720" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">チョムスキーの階層</text>
+    <text x="230" y="745" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#333">正規言語 ⊂ DCFL ⊂ 文脈自由言語</text>
+    <text x="230" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#333">⊂ 文脈依存言語 ⊂ 再帰的可算言語</text>
+    <text x="70" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">各レベル:</text>
+    <text x="70" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">Type 3 → Type 2 → Type 1 → Type 0</text>
+    <text x="70" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">生成規則の制約が段階的に緩和</text>
+    <text x="70" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">表現力の厳密な包含関係</text>
     
     <!-- Recognition Machines -->
     <rect x="420" y="700" width="340" height="140" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="590" y="720" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">認識機械</text>
-    <text x="430" y="740" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• Type 3: 有限オートマトン</text>
-    <text x="440" y="755" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">DFA, NFA, 正規表現</text>
-    <text x="430" y="770" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• Type 2: プッシュダウンオートマトン</text>
-    <text x="440" y="785" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">PDA, DPDA</text>
-    <text x="430" y="800" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• Type 1: 線形拘束オートマトン</text>
-    <text x="430" y="815" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• Type 0: チューリング機械</text>
-    <text x="440" y="830" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">万能計算モデル</text>
+    <text x="590" y="720" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">認識機械</text>
+    <text x="430" y="740" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• Type 3: 有限オートマトン</text>
+    <text x="440" y="755" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">DFA, NFA, 正規表現</text>
+    <text x="430" y="770" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• Type 2: プッシュダウンオートマトン</text>
+    <text x="440" y="785" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">PDA, DPDA</text>
+    <text x="430" y="800" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• Type 1: 線形拘束オートマトン</text>
+    <text x="430" y="815" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• Type 0: チューリング機械</text>
+    <text x="440" y="830" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">万能計算モデル</text>
     
     <!-- Practical Importance -->
     <rect x="780" y="700" width="360" height="140" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="960" y="720" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">実用的重要性</text>
-    <text x="790" y="740" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 正規言語: テキスト処理、字句解析</text>
-    <text x="790" y="755" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• DCFL: プログラミング言語構文</text>
-    <text x="790" y="770" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 文脈自由: 構造化データ、XML</text>
-    <text x="790" y="785" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 文脈依存: 型システム、制約</text>
-    <text x="790" y="800" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 再帰的可算: 一般計算、AI</text>
-    <text x="790" y="820" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">各レベルが異なる応用分野で活用</text>
-    <text x="790" y="835" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">計算複雑性と表現力のトレードオフ</text>
+    <text x="960" y="720" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">実用的重要性</text>
+    <text x="790" y="740" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 正規言語: テキスト処理、字句解析</text>
+    <text x="790" y="755" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• DCFL: プログラミング言語構文</text>
+    <text x="790" y="770" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 文脈自由: 構造化データ、XML</text>
+    <text x="790" y="785" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 文脈依存: 型システム、制約</text>
+    <text x="790" y="800" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 再帰的可算: 一般計算、AI</text>
+    <text x="790" y="820" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">各レベルが異なる応用分野で活用</text>
+    <text x="790" y="835" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">計算複雑性と表現力のトレードオフ</text>
   </g>
 </svg>

--- a/docs/assets/images/diagrams/ch3_context_free_languages_grammars.svg
+++ b/docs/assets/images/diagrams/ch3_context_free_languages_grammars.svg
@@ -7,7 +7,7 @@
   <rect width="1200" height="900" fill="#f8f9fa"/>
   
   <!-- Title -->
-  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="24" font-weight="bold" fill="#1a1a1a">文脈自由言語と文法</text>
+  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="24" font-weight="bold" fill="#1a1a1a">文脈自由言語と文法</text>
   
   <!-- Main Container -->
   <rect x="20" y="50" width="1160" height="830" fill="none" stroke="#e1e5e9" stroke-width="2" rx="10"/>
@@ -15,120 +15,120 @@
   <!-- Section 1: Context-Free Grammar -->
   <g id="cfg-definition">
     <rect x="40" y="80" width="560" height="200" fill="#e3f2fd" stroke="#1976d2" stroke-width="2" rx="8"/>
-    <text x="320" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#1976d2">文脈自由文法(CFG)</text>
+    <text x="320" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#1976d2">文脈自由文法(CFG)</text>
     
     <!-- CFG Definition -->
     <rect x="60" y="120" width="220" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="170" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">G = (V, Σ, R, S)</text>
-    <text x="70" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• V: 変数(非終端記号)</text>
-    <text x="70" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• Σ: 終端記号</text>
-    <text x="70" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• R: 生成規則 A → α</text>
-    <text x="70" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• S: 開始記号</text>
-    <text x="70" y="225" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">制約:</text>
-    <text x="70" y="240" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">V ∩ Σ = ∅</text>
-    <text x="70" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">A ∈ V, α ∈ (V ∪ Σ)*</text>
+    <text x="170" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">G = (V, Σ, R, S)</text>
+    <text x="70" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• V: 変数(非終端記号)</text>
+    <text x="70" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• Σ: 終端記号</text>
+    <text x="70" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• R: 生成規則 A → α</text>
+    <text x="70" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• S: 開始記号</text>
+    <text x="70" y="225" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">制約:</text>
+    <text x="70" y="240" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">V ∩ Σ = ∅</text>
+    <text x="70" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">A ∈ V, α ∈ (V ∪ Σ)*</text>
     
     <!-- Production Rules -->
     <rect x="290" y="120" width="160" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="370" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">生成規則の例</text>
-    <text x="300" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">S → 0S1 | ε</text>
-    <text x="300" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• 0ⁿ1ⁿを生成</text>
-    <text x="300" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• 再帰的構造</text>
-    <text x="300" y="210" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">E → E+E | E*E</text>
-    <text x="310" y="225" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">| (E) | id</text>
-    <text x="300" y="240" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• 算術式の文法</text>
-    <text x="300" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• 演算子の優先順位問題</text>
+    <text x="370" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">生成規則の例</text>
+    <text x="300" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">S → 0S1 | ε</text>
+    <text x="300" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• 0ⁿ1ⁿを生成</text>
+    <text x="300" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• 再帰的構造</text>
+    <text x="300" y="210" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">E → E+E | E*E</text>
+    <text x="310" y="225" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">| (E) | id</text>
+    <text x="300" y="240" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• 算術式の文法</text>
+    <text x="300" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• 演算子の優先順位問題</text>
     
     <!-- Derivation -->
     <rect x="460" y="120" width="130" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="525" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">導出過程</text>
-    <text x="470" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">直接導出:</text>
-    <text x="470" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">uAv ⇒ uαv</text>
-    <text x="470" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">導出: ⇒*の</text>
-    <text x="470" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">反射推移閉包</text>
-    <text x="470" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">左導出、右導出</text>
-    <text x="470" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">構文解析に重要</text>
+    <text x="525" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">導出過程</text>
+    <text x="470" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">直接導出:</text>
+    <text x="470" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">uAv ⇒ uαv</text>
+    <text x="470" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">導出: ⇒*の</text>
+    <text x="470" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">反射推移閉包</text>
+    <text x="470" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">左導出、右導出</text>
+    <text x="470" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">構文解析に重要</text>
   </g>
   
   <!-- Section 2: Parse Trees and Ambiguity -->
   <g id="parse-trees">
     <rect x="620" y="80" width="540" height="200" fill="#fff3e0" stroke="#f57c00" stroke-width="2" rx="8"/>
-    <text x="890" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#f57c00">導出木と曖昧性</text>
+    <text x="890" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#f57c00">導出木と曖昧性</text>
     
     <!-- Parse Tree Structure -->
     <rect x="640" y="120" width="160" height="140" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="720" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">導出木の構造</text>
-    <text x="650" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 根: 開始記号</text>
-    <text x="650" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 内部ノード: 変数</text>
-    <text x="650" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 葉: 終端記号またはε</text>
-    <text x="650" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 子の関係が生成規則</text>
-    <text x="650" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">　に対応</text>
-    <text x="650" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 左から右への順序で</text>
-    <text x="650" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">　文字列を生成</text>
+    <text x="720" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">導出木の構造</text>
+    <text x="650" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 根: 開始記号</text>
+    <text x="650" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 内部ノード: 変数</text>
+    <text x="650" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 葉: 終端記号またはε</text>
+    <text x="650" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 子の関係が生成規則</text>
+    <text x="650" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">　に対応</text>
+    <text x="650" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 左から右への順序で</text>
+    <text x="650" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">　文字列を生成</text>
     
     <!-- Ambiguity -->
     <rect x="810" y="120" width="170" height="140" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="895" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">曖昧性の問題</text>
-    <text x="820" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">同じ文字列に複数の導出木</text>
-    <text x="895" y="175" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">例: a+a×aの解釈</text>
-    <text x="895" y="190" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">1. (a+a)×a</text>
-    <text x="895" y="205" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">2. a+(a×a)</text>
-    <text x="820" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">優先順位で解決</text>
-    <text x="820" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">文法の書き換えが必要</text>
+    <text x="895" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">曖昧性の問題</text>
+    <text x="820" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">同じ文字列に複数の導出木</text>
+    <text x="895" y="175" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">例: a+a×aの解釈</text>
+    <text x="895" y="190" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">1. (a+a)×a</text>
+    <text x="895" y="205" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">2. a+(a×a)</text>
+    <text x="820" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">優先順位で解決</text>
+    <text x="820" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">文法の書き換えが必要</text>
     
     <!-- Derivation Types -->
     <rect x="990" y="120" width="160" height="140" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="1070" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">導出の種類</text>
-    <text x="1000" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">左導出:</text>
-    <text x="1000" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">最左の変数を展開</text>
-    <text x="1000" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif" font-size="10" fill="#555">右導出:</text>
-    <text x="1000" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">最右の変数を展開</text>
-    <text x="1000" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">構文解析で重要</text>
-    <text x="1000" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">一意性の保証</text>
+    <text x="1070" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">導出の種類</text>
+    <text x="1000" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">左導出:</text>
+    <text x="1000" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">最左の変数を展開</text>
+    <text x="1000" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">右導出:</text>
+    <text x="1000" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">最右の変数を展開</text>
+    <text x="1000" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">構文解析で重要</text>
+    <text x="1000" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">一意性の保証</text>
   </g>
   
   <!-- Section 3: Visual Example -->
   <g id="visual-example">
     <rect x="40" y="300" width="1120" height="180" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="2" rx="8"/>
-    <text x="600" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#7b1fa2">導出例: S → 0S1 | ε で 0011 を生成</text>
+    <text x="600" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#7b1fa2">導出例: S → 0S1 | ε で 0011 を生成</text>
     
     <!-- Derivation Sequence -->
     <g id="derivation-sequence">
-      <text x="80" y="355" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">導出過程:</text>
-      <text x="100" y="375" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">S ⇒ 0S1 ⇒ 00S11 ⇒ 00ε11 ⇒ 0011</text>
+      <text x="80" y="355" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">導出過程:</text>
+      <text x="100" y="375" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">S ⇒ 0S1 ⇒ 00S11 ⇒ 00ε11 ⇒ 0011</text>
     </g>
     
     <!-- Parse Tree -->
     <g id="parse-tree">
-      <text x="600" y="355" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">対応する導出木:</text>
+      <text x="600" y="355" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">対応する導出木:</text>
       
       <!-- Root S -->
       <circle cx="600" cy="385" r="12" fill="#ffffff" stroke="#7b1fa2" stroke-width="2"/>
-      <text x="600" y="390" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#7b1fa2">S</text>
+      <text x="600" y="390" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#7b1fa2">S</text>
       
       <!-- First level: 0, S, 1 -->
       <circle cx="550" cy="420" r="10" fill="#ffffff" stroke="#4caf50" stroke-width="2"/>
-      <text x="550" y="425" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" font-weight="bold" fill="#4caf50">0</text>
+      <text x="550" y="425" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" font-weight="bold" fill="#4caf50">0</text>
       
       <circle cx="600" cy="420" r="12" fill="#ffffff" stroke="#7b1fa2" stroke-width="2"/>
-      <text x="600" y="425" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#7b1fa2">S</text>
+      <text x="600" y="425" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#7b1fa2">S</text>
       
       <circle cx="650" cy="420" r="10" fill="#ffffff" stroke="#4caf50" stroke-width="2"/>
-      <text x="650" y="425" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" font-weight="bold" fill="#4caf50">1</text>
+      <text x="650" y="425" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" font-weight="bold" fill="#4caf50">1</text>
       
       <!-- Second level: 0, S, 1 -->
       <circle cx="570" cy="455" r="10" fill="#ffffff" stroke="#4caf50" stroke-width="2"/>
-      <text x="570" y="460" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" font-weight="bold" fill="#4caf50">0</text>
+      <text x="570" y="460" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" font-weight="bold" fill="#4caf50">0</text>
       
       <circle cx="600" cy="455" r="12" fill="#ffffff" stroke="#7b1fa2" stroke-width="2"/>
-      <text x="600" y="460" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#7b1fa2">S</text>
+      <text x="600" y="460" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#7b1fa2">S</text>
       
       <circle cx="630" cy="455" r="10" fill="#ffffff" stroke="#4caf50" stroke-width="2"/>
-      <text x="630" y="460" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" font-weight="bold" fill="#4caf50">1</text>
+      <text x="630" y="460" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" font-weight="bold" fill="#4caf50">1</text>
       
       <!-- Third level: ε -->
       <circle cx="600" cy="485" r="10" fill="#ffffff" stroke="#9e9e9e" stroke-width="2"/>
-      <text x="600" y="490" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" font-weight="bold" fill="#9e9e9e">ε</text>
+      <text x="600" y="490" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" font-weight="bold" fill="#9e9e9e">ε</text>
       
       <!-- Connections -->
       <path d="M 588 395 L 562 410" fill="none" stroke="#333" stroke-width="1"/>
@@ -142,104 +142,104 @@
       <path d="M 600 467 L 600 475" fill="none" stroke="#333" stroke-width="1"/>
       
       <!-- Yield -->
-      <text x="600" y="520" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">文字列: 0 0 ε 1 1 = 0011</text>
+      <text x="600" y="520" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">文字列: 0 0 ε 1 1 = 0011</text>
     </g>
     
     <!-- Alternative representation -->
     <g id="step-by-step">
-      <text x="850" y="355" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">段階的導出:</text>
-      <text x="870" y="375" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">1. S → 0S1 を適用</text>
-      <text x="870" y="390" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">2. 内側のS → 0S1 を適用</text>
-      <text x="870" y="405" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">3. 最内のS → ε を適用</text>
-      <text x="870" y="420" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">4. εを削除して0011を得る</text>
-      <text x="870" y="440" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">この文法は{0ⁿ1ⁿ | n ≥ 0}を生成</text>
-      <text x="870" y="455" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">正規言語を超える表現力</text>
+      <text x="850" y="355" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">段階的導出:</text>
+      <text x="870" y="375" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">1. S → 0S1 を適用</text>
+      <text x="870" y="390" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">2. 内側のS → 0S1 を適用</text>
+      <text x="870" y="405" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">3. 最内のS → ε を適用</text>
+      <text x="870" y="420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">4. εを削除して0011を得る</text>
+      <text x="870" y="440" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">この文法は{0ⁿ1ⁿ | n ≥ 0}を生成</text>
+      <text x="870" y="455" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">正規言語を超える表現力</text>
     </g>
   </g>
   
   <!-- Section 4: Normal Forms -->
   <g id="normal-forms">
     <rect x="40" y="500" width="1120" height="180" fill="#e8f5e8" stroke="#388e3c" stroke-width="2" rx="8"/>
-    <text x="600" y="525" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#388e3c">標準形</text>
+    <text x="600" y="525" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#388e3c">標準形</text>
     
     <!-- Chomsky Normal Form -->
     <rect x="60" y="540" width="270" height="120" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="195" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">Chomsky標準形(CNF)</text>
-    <text x="70" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">A → BC (変数→2個の変数)</text>
-    <text x="70" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">A → a (変数→1個の終端記号)</text>
-    <text x="70" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">S → ε (特別な場合のみ)</text>
-    <text x="70" y="630" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">利点:</text>
-    <text x="70" y="645" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• CYKアルゴリズムに適用</text>
-    <text x="70" y="655" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• 構文解析の効率化</text>
+    <text x="195" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">Chomsky標準形(CNF)</text>
+    <text x="70" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">A → BC (変数→2個の変数)</text>
+    <text x="70" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">A → a (変数→1個の終端記号)</text>
+    <text x="70" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">S → ε (特別な場合のみ)</text>
+    <text x="70" y="630" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">利点:</text>
+    <text x="70" y="645" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• CYKアルゴリズムに適用</text>
+    <text x="70" y="655" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• 構文解析の効率化</text>
     
     <!-- Greibach Normal Form -->
     <rect x="340" y="540" width="270" height="120" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="475" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">Greibach標準形(GNF)</text>
-    <text x="350" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">A → aα</text>
-    <text x="350" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">終端記号で始まる</text>
-    <text x="350" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">左再帰の除去</text>
-    <text x="350" y="630" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">利点:</text>
-    <text x="350" y="645" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• 予測解析に適用</text>
-    <text x="350" y="655" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• PDAとの対応</text>
+    <text x="475" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">Greibach標準形(GNF)</text>
+    <text x="350" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">A → aα</text>
+    <text x="350" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">終端記号で始まる</text>
+    <text x="350" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">左再帰の除去</text>
+    <text x="350" y="630" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">利点:</text>
+    <text x="350" y="645" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• 予測解析に適用</text>
+    <text x="350" y="655" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• PDAとの対応</text>
     
     <!-- Conversion Algorithm -->
     <rect x="620" y="540" width="250" height="120" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="745" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">変換アルゴリズム</text>
-    <text x="630" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">1. ε-規則の除去</text>
-    <text x="630" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">2. 単位規則の除去</text>
-    <text x="630" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">3. 無用記号の除去</text>
-    <text x="630" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">4. 規則の分解</text>
-    <text x="630" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">5. 終端記号の分離</text>
-    <text x="630" y="655" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">系統的な手順で変換</text>
+    <text x="745" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">変換アルゴリズム</text>
+    <text x="630" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">1. ε-規則の除去</text>
+    <text x="630" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">2. 単位規則の除去</text>
+    <text x="630" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">3. 無用記号の除去</text>
+    <text x="630" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">4. 規則の分解</text>
+    <text x="630" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">5. 終端記号の分離</text>
+    <text x="630" y="655" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">系統的な手順で変換</text>
     
     <!-- Practical Applications -->
     <rect x="880" y="540" width="270" height="120" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="1015" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">実用的意義</text>
-    <text x="890" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">CNF:</text>
-    <text x="900" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• O(n³)構文解析</text>
-    <text x="900" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 動的計画法の適用</text>
-    <text x="890" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">GNF:</text>
-    <text x="900" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• LL(1)パーサ設計</text>
-    <text x="900" y="655" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 効率的な実装</text>
+    <text x="1015" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">実用的意義</text>
+    <text x="890" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">CNF:</text>
+    <text x="900" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• O(n³)構文解析</text>
+    <text x="900" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 動的計画法の適用</text>
+    <text x="890" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">GNF:</text>
+    <text x="900" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• LL(1)パーサ設計</text>
+    <text x="900" y="655" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 効率的な実装</text>
   </g>
   
   <!-- Section 5: CFL Pumping Lemma -->
   <g id="cfl-pumping">
     <rect x="40" y="700" width="1120" height="160" fill="#ffebee" stroke="#d32f2f" stroke-width="2" rx="8"/>
-    <text x="600" y="725" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#d32f2f">CFGのPumping補題</text>
+    <text x="600" y="725" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#d32f2f">CFGのPumping補題</text>
     
     <!-- CFL Pumping Statement -->
     <rect x="60" y="740" width="280" height="105" fill="#ffffff" stroke="#d32f2f" stroke-width="1" rx="4"/>
-    <text x="200" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#d32f2f">文脈自由言語のPumping補題</text>
-    <text x="70" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">十分長いs ∈ Lに対し</text>
-    <text x="70" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">s = uvxyzと分解</text>
-    <text x="70" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">uvⁱxyⁱz ∈ L (∀i ≥ 0)</text>
-    <text x="70" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">2箇所で同時にpumping</text>
+    <text x="200" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#d32f2f">文脈自由言語のPumping補題</text>
+    <text x="70" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">十分長いs ∈ Lに対し</text>
+    <text x="70" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">s = uvxyzと分解</text>
+    <text x="70" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">uvⁱxyⁱz ∈ L (∀i ≥ 0)</text>
+    <text x="70" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">2箇所で同時にpumping</text>
     
     <!-- CFL Conditions -->
     <rect x="360" y="740" width="200" height="105" fill="#ffffff" stroke="#d32f2f" stroke-width="1" rx="4"/>
-    <text x="460" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#d32f2f">条件</text>
-    <text x="370" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#d32f2f">1. |vxy| ≤ p</text>
-    <text x="380" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">中央部分は短い</text>
-    <text x="370" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#d32f2f">2. |vy| &gt; 0</text>
-    <text x="380" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">vとyは同時に空でない</text>
-    <text x="370" y="840" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#d32f2f">3. vとyを同時にpumping</text>
+    <text x="460" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#d32f2f">条件</text>
+    <text x="370" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#d32f2f">1. |vxy| ≤ p</text>
+    <text x="380" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">中央部分は短い</text>
+    <text x="370" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#d32f2f">2. |vy| &gt; 0</text>
+    <text x="380" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">vとyは同時に空でない</text>
+    <text x="370" y="840" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#d32f2f">3. vとyを同時にpumping</text>
     
     <!-- CFL Example -->
     <rect x="580" y="740" width="300" height="105" fill="#ffffff" stroke="#d32f2f" stroke-width="1" rx="4"/>
-    <text x="730" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#d32f2f">非文脈自由言語</text>
-    <text x="730" y="785" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">{aⁿbⁿcⁿ | n ≥ 0}</text>
-    <text x="590" y="805" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">3種類の文字の個数が等しい言語</text>
-    <text x="590" y="820" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">|vxy| ≤ pより、vxyは高々2種類の文字</text>
-    <text x="590" y="835" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">∴ pumpingで3文字の均等性が破れる</text>
+    <text x="730" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#d32f2f">非文脈自由言語</text>
+    <text x="730" y="785" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">{aⁿbⁿcⁿ | n ≥ 0}</text>
+    <text x="590" y="805" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">3種類の文字の個数が等しい言語</text>
+    <text x="590" y="820" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">|vxy| ≤ pより、vxyは高々2種類の文字</text>
+    <text x="590" y="835" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">∴ pumpingで3文字の均等性が破れる</text>
     
     <!-- Proof Intuition -->
     <rect x="900" y="740" width="240" height="105" fill="#ffffff" stroke="#d32f2f" stroke-width="1" rx="4"/>
-    <text x="1020" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#d32f2f">証明の直観</text>
-    <text x="910" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">CNFの導出木で考える</text>
-    <text x="910" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">十分深い木では変数が重複</text>
-    <text x="910" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">重複した変数の部分木を</text>
-    <text x="910" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">繰り返すことでpumping</text>
-    <text x="910" y="840" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">2箇所同時の制約が鍵</text>
+    <text x="1020" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#d32f2f">証明の直観</text>
+    <text x="910" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">CNFの導出木で考える</text>
+    <text x="910" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">十分深い木では変数が重複</text>
+    <text x="910" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">重複した変数の部分木を</text>
+    <text x="910" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">繰り返すことでpumping</text>
+    <text x="910" y="840" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">2箇所同時の制約が鍵</text>
   </g>
 </svg>

--- a/docs/assets/images/diagrams/ch3_even_zeros_automaton.svg
+++ b/docs/assets/images/diagrams/ch3_even_zeros_automaton.svg
@@ -23,7 +23,7 @@
       }
       
       .state-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -46,7 +46,7 @@
       }
       
       .transition-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 16px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -54,7 +54,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -62,7 +62,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 400; 
         text-anchor: middle; 
@@ -70,7 +70,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch3_finite_automata_overview.svg
+++ b/docs/assets/images/diagrams/ch3_finite_automata_overview.svg
@@ -7,7 +7,7 @@
   <rect width="1200" height="800" fill="#f8f9fa"/>
   
   <!-- Title -->
-  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="24" font-weight="bold" fill="#1a1a1a">有限オートマトンの種類と特徴</text>
+  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="24" font-weight="bold" fill="#1a1a1a">有限オートマトンの種類と特徴</text>
   
   <!-- Main Container -->
   <rect x="20" y="50" width="1160" height="730" fill="none" stroke="#e1e5e9" stroke-width="2" rx="10"/>
@@ -15,270 +15,270 @@
   <!-- DFA Section -->
   <g id="dfa-section">
     <rect x="40" y="80" width="360" height="320" fill="#e3f2fd" stroke="#1976d2" stroke-width="2" rx="8"/>
-    <text x="220" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#1976d2">DFA（決定性有限オートマトン）</text>
+    <text x="220" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#1976d2">DFA（決定性有限オートマトン）</text>
     
     <!-- DFA Definition -->
     <rect x="50" y="120" width="340" height="80" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="220" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#1976d2">M = (Q, Σ, δ, q₀, F)</text>
-    <text x="60" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• Q: 状態集合　　• Σ: 入力アルファベット</text>
-    <text x="60" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• δ: Q × Σ → Q　• q₀: 初期状態</text>
-    <text x="60" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• F: 受理状態集合</text>
+    <text x="220" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#1976d2">M = (Q, Σ, δ, q₀, F)</text>
+    <text x="60" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• Q: 状態集合　　• Σ: 入力アルファベット</text>
+    <text x="60" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• δ: Q × Σ → Q　• q₀: 初期状態</text>
+    <text x="60" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• F: 受理状態集合</text>
     
     <!-- DFA Features -->
     <rect x="50" y="210" width="160" height="90" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="130" y="230" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">特徴</text>
-    <text x="60" y="245" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 各状態で各入力に対し</text>
-    <text x="60" y="255" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">　て唯一の遷移先</text>
-    <text x="60" y="270" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 決定的な計算</text>
-    <text x="60" y="285" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 効率的な実装</text>
+    <text x="130" y="230" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">特徴</text>
+    <text x="60" y="245" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 各状態で各入力に対し</text>
+    <text x="60" y="255" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">　て唯一の遷移先</text>
+    <text x="60" y="270" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 決定的な計算</text>
+    <text x="60" y="285" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 効率的な実装</text>
     
     <!-- DFA Example -->
     <rect x="220" y="210" width="170" height="90" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="305" y="230" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">例: 0の個数が偶数</text>
-    <text x="230" y="245" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">q₀: 偶数個(受理)</text>
-    <text x="230" y="255" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">q₁: 奇数個</text>
-    <text x="230" y="270" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">δ(q₀,0)=q₁, δ(q₀,1)=q₀</text>
-    <text x="230" y="285" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">δ(q₁,0)=q₀, δ(q₁,1)=q₁</text>
+    <text x="305" y="230" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">例: 0の個数が偶数</text>
+    <text x="230" y="245" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">q₀: 偶数個(受理)</text>
+    <text x="230" y="255" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">q₁: 奇数個</text>
+    <text x="230" y="270" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">δ(q₀,0)=q₁, δ(q₀,1)=q₀</text>
+    <text x="230" y="285" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">δ(q₁,0)=q₀, δ(q₁,1)=q₁</text>
     
     <!-- DFA Visual Example -->
     <g id="dfa-visual">
-      <text x="220" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">状態遷移図</text>
+      <text x="220" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">状態遷移図</text>
       
       <!-- States -->
       <circle cx="150" cy="360" r="25" fill="#ffffff" stroke="#1976d2" stroke-width="2"/>
       <circle cx="150" cy="360" r="20" fill="none" stroke="#1976d2" stroke-width="1"/>
-      <text x="150" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">q₀</text>
+      <text x="150" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">q₀</text>
       
       <circle cx="290" cy="360" r="25" fill="#ffffff" stroke="#1976d2" stroke-width="2"/>
-      <text x="290" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">q₁</text>
+      <text x="290" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">q₁</text>
       
       <!-- Transitions -->
       <path d="M 175 350 Q 220 330 265 350" fill="none" stroke="#1976d2" stroke-width="2" marker-end="url(#arrowhead)"/>
-      <text x="220" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#1976d2">0</text>
+      <text x="220" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#1976d2">0</text>
       
       <path d="M 265 370 Q 220 390 175 370" fill="none" stroke="#1976d2" stroke-width="2" marker-end="url(#arrowhead)"/>
-      <text x="220" y="395" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#1976d2">0</text>
+      <text x="220" y="395" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#1976d2">0</text>
       
       <!-- Self loops -->
       <path d="M 130 340 Q 110 320 130 335" fill="none" stroke="#1976d2" stroke-width="2" marker-end="url(#arrowhead)"/>
-      <text x="115" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#1976d2">1</text>
+      <text x="115" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#1976d2">1</text>
       
       <path d="M 310 340 Q 330 320 310 335" fill="none" stroke="#1976d2" stroke-width="2" marker-end="url(#arrowhead)"/>
-      <text x="325" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#1976d2">1</text>
+      <text x="325" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#1976d2">1</text>
       
       <!-- Start arrow -->
       <path d="M 110 360 L 125 360" fill="none" stroke="#1976d2" stroke-width="2" marker-end="url(#arrowhead)"/>
-      <text x="100" y="356" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#1976d2">start</text>
+      <text x="100" y="356" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#1976d2">start</text>
     </g>
   </g>
   
   <!-- NFA Section -->
   <g id="nfa-section">
     <rect x="420" y="80" width="360" height="320" fill="#fff3e0" stroke="#f57c00" stroke-width="2" rx="8"/>
-    <text x="600" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#f57c00">NFA（非決定性有限オートマトン）</text>
+    <text x="600" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#f57c00">NFA（非決定性有限オートマトン）</text>
     
     <!-- NFA Definition -->
     <rect x="430" y="120" width="340" height="80" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="600" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#f57c00">M = (Q, Σ, δ, q₀, F)</text>
-    <text x="440" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• δ: Q × Σ → P(Q)　（P(Q)は Q の冪集合）</text>
-    <text x="440" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 非決定的選択</text>
-    <text x="440" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 並行計算パス</text>
+    <text x="600" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#f57c00">M = (Q, Σ, δ, q₀, F)</text>
+    <text x="440" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• δ: Q × Σ → P(Q)　（P(Q)は Q の冪集合）</text>
+    <text x="440" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 非決定的選択</text>
+    <text x="440" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 並行計算パス</text>
     
     <!-- NFA Features -->
     <rect x="430" y="210" width="160" height="90" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="510" y="230" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">特徴</text>
-    <text x="440" y="245" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 複数の遷移先可能</text>
-    <text x="440" y="255" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 推測による計算</text>
-    <text x="440" y="270" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• コンパクトな表現</text>
-    <text x="440" y="285" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 設計の柔軟性</text>
+    <text x="510" y="230" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">特徴</text>
+    <text x="440" y="245" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 複数の遷移先可能</text>
+    <text x="440" y="255" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 推測による計算</text>
+    <text x="440" y="270" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• コンパクトな表現</text>
+    <text x="440" y="285" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 設計の柔軟性</text>
     
     <!-- NFA Example -->
     <rect x="600" y="210" width="170" height="90" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="685" y="230" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">例: 末尾から3番目が1</text>
-    <text x="610" y="245" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 推測: 今の1が末尾から</text>
-    <text x="610" y="255" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">　3番目</text>
-    <text x="610" y="270" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 3文字先の文字列終端</text>
-    <text x="610" y="285" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">　で受理</text>
+    <text x="685" y="230" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">例: 末尾から3番目が1</text>
+    <text x="610" y="245" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 推測: 今の1が末尾から</text>
+    <text x="610" y="255" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">　3番目</text>
+    <text x="610" y="270" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 3文字先の文字列終端</text>
+    <text x="610" y="285" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">　で受理</text>
     
     <!-- NFA Visual Example -->
     <g id="nfa-visual">
-      <text x="600" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">状態遷移図</text>
+      <text x="600" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">状態遷移図</text>
       
       <!-- States -->
       <circle cx="480" cy="360" r="20" fill="#ffffff" stroke="#f57c00" stroke-width="2"/>
-      <text x="480" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#f57c00">q₀</text>
+      <text x="480" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#f57c00">q₀</text>
       
       <circle cx="560" cy="360" r="20" fill="#ffffff" stroke="#f57c00" stroke-width="2"/>
-      <text x="560" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#f57c00">q₁</text>
+      <text x="560" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#f57c00">q₁</text>
       
       <circle cx="640" cy="360" r="20" fill="#ffffff" stroke="#f57c00" stroke-width="2"/>
-      <text x="640" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#f57c00">q₂</text>
+      <text x="640" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#f57c00">q₂</text>
       
       <circle cx="720" cy="360" r="20" fill="#ffffff" stroke="#f57c00" stroke-width="2"/>
       <circle cx="720" cy="360" r="15" fill="none" stroke="#f57c00" stroke-width="1"/>
-      <text x="720" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" font-weight="bold" fill="#f57c00">q₃</text>
+      <text x="720" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" font-weight="bold" fill="#f57c00">q₃</text>
       
       <!-- Transitions -->
       <path d="M 500 360 L 540 360" fill="none" stroke="#f57c00" stroke-width="2" marker-end="url(#arrowhead-orange)"/>
-      <text x="520" y="355" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#f57c00">1</text>
+      <text x="520" y="355" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#f57c00">1</text>
       
       <path d="M 580 360 L 620 360" fill="none" stroke="#f57c00" stroke-width="2" marker-end="url(#arrowhead-orange)"/>
-      <text x="600" y="355" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#f57c00">0,1</text>
+      <text x="600" y="355" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#f57c00">0,1</text>
       
       <path d="M 660 360 L 700 360" fill="none" stroke="#f57c00" stroke-width="2" marker-end="url(#arrowhead-orange)"/>
-      <text x="680" y="355" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#f57c00">0,1</text>
+      <text x="680" y="355" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#f57c00">0,1</text>
       
       <!-- Self loops -->
       <path d="M 460 340 Q 440 320 460 340" fill="none" stroke="#f57c00" stroke-width="2" marker-end="url(#arrowhead-orange)"/>
-      <text x="445" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#f57c00">0,1</text>
+      <text x="445" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#f57c00">0,1</text>
       
       <!-- Start arrow -->
       <path d="M 440 360 L 460 360" fill="none" stroke="#f57c00" stroke-width="2" marker-end="url(#arrowhead-orange)"/>
-      <text x="430" y="356" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#f57c00">start</text>
+      <text x="430" y="356" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#f57c00">start</text>
     </g>
   </g>
   
   <!-- ε-NFA Section -->
   <g id="epsilon-nfa-section">
     <rect x="800" y="80" width="360" height="320" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="2" rx="8"/>
-    <text x="980" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#7b1fa2">ε-NFA</text>
+    <text x="980" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#7b1fa2">ε-NFA</text>
     
     <!-- ε-NFA Definition -->
     <rect x="810" y="120" width="340" height="80" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="980" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#7b1fa2">ε-遷移付きNFA</text>
-    <text x="820" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 空文字列での遷移</text>
-    <text x="820" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• δ: Q × (Σ ∪ {ε}) → P(Q)</text>
-    <text x="820" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• ECLOSE(ε閉包)で処理</text>
+    <text x="980" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#7b1fa2">ε-遷移付きNFA</text>
+    <text x="820" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 空文字列での遷移</text>
+    <text x="820" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• δ: Q × (Σ ∪ {ε}) → P(Q)</text>
+    <text x="820" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• ECLOSE(ε閉包)で処理</text>
     
     <!-- ε-NFA Features -->
     <rect x="810" y="210" width="340" height="90" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="980" y="230" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">使用例</text>
-    <text x="820" y="245" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 正規表現からの変換</text>
-    <text x="820" y="255" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 複数のオートマトンの結合</text>
-    <text x="820" y="270" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 構成的な設計</text>
-    <text x="820" y="285" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• より直観的な表現</text>
+    <text x="980" y="230" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">使用例</text>
+    <text x="820" y="245" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 正規表現からの変換</text>
+    <text x="820" y="255" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 複数のオートマトンの結合</text>
+    <text x="820" y="270" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 構成的な設計</text>
+    <text x="820" y="285" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• より直観的な表現</text>
     
     <!-- ε-closure example -->
     <g id="epsilon-closure">
-      <text x="980" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">ε-閉包の例</text>
+      <text x="980" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">ε-閉包の例</text>
       
       <!-- States -->
       <circle cx="890" cy="360" r="18" fill="#ffffff" stroke="#7b1fa2" stroke-width="2"/>
-      <text x="890" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#7b1fa2">q₀</text>
+      <text x="890" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#7b1fa2">q₀</text>
       
       <circle cx="950" cy="340" r="18" fill="#ffffff" stroke="#7b1fa2" stroke-width="2"/>
-      <text x="950" y="345" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#7b1fa2">q₁</text>
+      <text x="950" y="345" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#7b1fa2">q₁</text>
       
       <circle cx="950" cy="380" r="18" fill="#ffffff" stroke="#7b1fa2" stroke-width="2"/>
-      <text x="950" y="385" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#7b1fa2">q₂</text>
+      <text x="950" y="385" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#7b1fa2">q₂</text>
       
       <circle cx="1050" cy="360" r="18" fill="#ffffff" stroke="#7b1fa2" stroke-width="2"/>
       <circle cx="1050" cy="360" r="13" fill="none" stroke="#7b1fa2" stroke-width="1"/>
-      <text x="1050" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#7b1fa2">q₃</text>
+      <text x="1050" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#7b1fa2">q₃</text>
       
       <!-- ε-transitions -->
       <path d="M 908 355 L 932 345" fill="none" stroke="#7b1fa2" stroke-width="2" stroke-dasharray="3,2" marker-end="url(#arrowhead-purple)"/>
-      <text x="920" y="345" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#7b1fa2">ε</text>
+      <text x="920" y="345" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#7b1fa2">ε</text>
       
       <path d="M 908 365 L 932 375" fill="none" stroke="#7b1fa2" stroke-width="2" stroke-dasharray="3,2" marker-end="url(#arrowhead-purple)"/>
-      <text x="920" y="380" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#7b1fa2">ε</text>
+      <text x="920" y="380" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#7b1fa2">ε</text>
       
       <path d="M 968 345 L 1032 355" fill="none" stroke="#7b1fa2" stroke-width="2" marker-end="url(#arrowhead-purple)"/>
-      <text x="1000" y="345" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#7b1fa2">a</text>
+      <text x="1000" y="345" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#7b1fa2">a</text>
       
       <path d="M 968 375 L 1032 365" fill="none" stroke="#7b1fa2" stroke-width="2" marker-end="url(#arrowhead-purple)"/>
-      <text x="1000" y="385" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#7b1fa2">b</text>
+      <text x="1000" y="385" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#7b1fa2">b</text>
       
       <!-- Start arrow -->
       <path d="M 860 360 L 872 360" fill="none" stroke="#7b1fa2" stroke-width="2" marker-end="url(#arrowhead-purple)"/>
-      <text x="850" y="356" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#7b1fa2">start</text>
+      <text x="850" y="356" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#7b1fa2">start</text>
     </g>
   </g>
   
   <!-- Equivalence and Conversion -->
   <g id="equivalence-section">
     <rect x="40" y="420" width="560" height="180" fill="#e8f5e8" stroke="#388e3c" stroke-width="2" rx="8"/>
-    <text x="320" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#388e3c">等価性と変換</text>
+    <text x="320" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#388e3c">等価性と変換</text>
     
     <!-- Equivalence -->
     <rect x="60" y="460" width="250" height="130" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="185" y="480" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#388e3c">計算能力の等価性</text>
-    <text x="185" y="505" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="16" font-weight="bold" fill="#333">DFA ≡ NFA ≡ ε-NFA</text>
-    <text x="80" y="525" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 部分集合構成法</text>
-    <text x="80" y="540" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 状態爆発の可能性</text>
-    <text x="80" y="555" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 同じ言語クラスを認識</text>
-    <text x="80" y="570" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• 正規言語との一対一対応</text>
+    <text x="185" y="480" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#388e3c">計算能力の等価性</text>
+    <text x="185" y="505" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="16" font-weight="bold" fill="#333">DFA ≡ NFA ≡ ε-NFA</text>
+    <text x="80" y="525" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 部分集合構成法</text>
+    <text x="80" y="540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 状態爆発の可能性</text>
+    <text x="80" y="555" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 同じ言語クラスを認識</text>
+    <text x="80" y="570" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• 正規言語との一対一対応</text>
     
     <!-- Conversion -->
     <rect x="330" y="460" width="250" height="130" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="455" y="480" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#388e3c">変換アルゴリズム</text>
-    <text x="350" y="500" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">NFA → DFA:</text>
-    <text x="360" y="515" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 部分集合構成法</text>
-    <text x="360" y="527" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 最悪 O(2ⁿ) 状態</text>
-    <text x="350" y="545" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">ε-NFA → NFA:</text>
-    <text x="360" y="560" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• ε閉包計算</text>
-    <text x="350" y="578" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">DFA最小化: 等価状態結合</text>
+    <text x="455" y="480" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#388e3c">変換アルゴリズム</text>
+    <text x="350" y="500" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">NFA → DFA:</text>
+    <text x="360" y="515" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 部分集合構成法</text>
+    <text x="360" y="527" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 最悪 O(2ⁿ) 状態</text>
+    <text x="350" y="545" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">ε-NFA → NFA:</text>
+    <text x="360" y="560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• ε閉包計算</text>
+    <text x="350" y="578" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">DFA最小化: 等価状態結合</text>
   </g>
   
   <!-- Computational Complexity -->
   <g id="complexity-section">
     <rect x="620" y="420" width="540" height="180" fill="#fff8e1" stroke="#f9a825" stroke-width="2" rx="8"/>
-    <text x="890" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#f9a825">計算複雑性と実用性</text>
+    <text x="890" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#f9a825">計算複雑性と実用性</text>
     
     <!-- Time Complexity -->
     <rect x="640" y="460" width="160" height="130" fill="#ffffff" stroke="#f9a825" stroke-width="1" rx="4"/>
-    <text x="720" y="480" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f9a825">時間複雑性</text>
-    <text x="650" y="500" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">DFA認識: O(n)</text>
-    <text x="650" y="515" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">NFA認識: O(n·|Q|²)</text>
-    <text x="650" y="530" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">NFA→DFA: O(2^|Q|)</text>
-    <text x="650" y="545" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">DFA最小化: O(n log n)</text>
-    <text x="650" y="565" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">nは入力長、|Q|は状態数</text>
+    <text x="720" y="480" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f9a825">時間複雑性</text>
+    <text x="650" y="500" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">DFA認識: O(n)</text>
+    <text x="650" y="515" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">NFA認識: O(n·|Q|²)</text>
+    <text x="650" y="530" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">NFA→DFA: O(2^|Q|)</text>
+    <text x="650" y="545" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">DFA最小化: O(n log n)</text>
+    <text x="650" y="565" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">nは入力長、|Q|は状態数</text>
     
     <!-- Space Complexity -->
     <rect x="810" y="460" width="160" height="130" fill="#ffffff" stroke="#f9a825" stroke-width="1" rx="4"/>
-    <text x="890" y="480" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f9a825">空間複雑性</text>
-    <text x="820" y="500" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">DFA: O(|Q|)</text>
-    <text x="820" y="515" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">NFA: O(|Q|)</text>
-    <text x="820" y="530" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">部分集合構成:</text>
-    <text x="820" y="545" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">　最悪 O(2^|Q|)</text>
-    <text x="820" y="565" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">実用的には大幅に改善</text>
+    <text x="890" y="480" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f9a825">空間複雑性</text>
+    <text x="820" y="500" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">DFA: O(|Q|)</text>
+    <text x="820" y="515" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">NFA: O(|Q|)</text>
+    <text x="820" y="530" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">部分集合構成:</text>
+    <text x="820" y="545" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">　最悪 O(2^|Q|)</text>
+    <text x="820" y="565" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">実用的には大幅に改善</text>
     
     <!-- Applications -->
     <rect x="980" y="460" width="170" height="130" fill="#ffffff" stroke="#f9a825" stroke-width="1" rx="4"/>
-    <text x="1065" y="480" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f9a825">実用的応用</text>
-    <text x="990" y="500" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 字句解析器</text>
-    <text x="990" y="515" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 正規表現エンジン</text>
-    <text x="990" y="530" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• プロトコル検証</text>
-    <text x="990" y="545" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• テキスト処理</text>
-    <text x="990" y="560" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• パターンマッチング</text>
+    <text x="1065" y="480" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f9a825">実用的応用</text>
+    <text x="990" y="500" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 字句解析器</text>
+    <text x="990" y="515" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 正規表現エンジン</text>
+    <text x="990" y="530" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• プロトコル検証</text>
+    <text x="990" y="545" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• テキスト処理</text>
+    <text x="990" y="560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• パターンマッチング</text>
     
   </g>
   
   <!-- Recognition Process Comparison -->
   <g id="recognition-process">
     <rect x="40" y="620" width="1120" height="140" fill="#fce4ec" stroke="#c2185b" stroke-width="2" rx="8"/>
-    <text x="600" y="645" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#c2185b">文字列認識プロセスの比較</text>
+    <text x="600" y="645" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#c2185b">文字列認識プロセスの比較</text>
     
     <!-- DFA Recognition -->
     <rect x="70" y="660" width="330" height="85" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="235" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">DFA認識プロセス</text>
-    <text x="80" y="700" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">1. 現在状態 = 初期状態</text>
-    <text x="80" y="715" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">2. 各入力文字に対して決定的遷移</text>
-    <text x="80" y="730" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">3. 最終状態が受理状態かチェック</text>
+    <text x="235" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">DFA認識プロセス</text>
+    <text x="80" y="700" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">1. 現在状態 = 初期状態</text>
+    <text x="80" y="715" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">2. 各入力文字に対して決定的遷移</text>
+    <text x="80" y="730" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">3. 最終状態が受理状態かチェック</text>
     
     <!-- NFA Recognition -->
     <rect x="420" y="660" width="330" height="85" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="585" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">NFA認識プロセス</text>
-    <text x="430" y="700" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">1. 現在状態集合 = {初期状態}</text>
-    <text x="430" y="715" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">2. 各入力文字に対して並行遷移</text>
-    <text x="430" y="730" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">3. 最終状態集合と受理状態の交集合</text>
+    <text x="585" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">NFA認識プロセス</text>
+    <text x="430" y="700" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">1. 現在状態集合 = {初期状態}</text>
+    <text x="430" y="715" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">2. 各入力文字に対して並行遷移</text>
+    <text x="430" y="730" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">3. 最終状態集合と受理状態の交集合</text>
     
     <!-- ε-NFA Recognition -->
     <rect x="770" y="660" width="330" height="85" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="935" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">ε-NFA認識プロセス</text>
-    <text x="780" y="700" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">1. 現在状態集合 = ECLOSE({初期状態})</text>
-    <text x="780" y="715" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">2. 各入力文字でε閉包を含む遷移</text>
-    <text x="780" y="730" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">3. 最終ε閉包と受理状態の交集合</text>
+    <text x="935" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">ε-NFA認識プロセス</text>
+    <text x="780" y="700" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">1. 現在状態集合 = ECLOSE({初期状態})</text>
+    <text x="780" y="715" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">2. 各入力文字でε閉包を含む遷移</text>
+    <text x="780" y="730" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">3. 最終ε閉包と受理状態の交集合</text>
   </g>
   
   <!-- Arrow markers -->

--- a/docs/assets/images/diagrams/ch3_finite_automata_types.svg
+++ b/docs/assets/images/diagrams/ch3_finite_automata_types.svg
@@ -14,11 +14,11 @@
       .concept-box { 
         rx: 6px; 
         ry: 6px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -26,7 +26,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .definition-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 13px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -42,7 +42,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -50,7 +50,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 
@@ -58,7 +58,7 @@
       }
       
       .state-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -67,7 +67,7 @@
       }
       
       .transition-label { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch3_finite_automaton_example.svg
+++ b/docs/assets/images/diagrams/ch3_finite_automaton_example.svg
@@ -23,7 +23,7 @@
       }
       
       .state-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -39,7 +39,7 @@
       }
       
       .transition-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 16px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -47,7 +47,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -55,7 +55,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 400; 
         text-anchor: middle; 
@@ -63,7 +63,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch3_formal_language_concepts.svg
+++ b/docs/assets/images/diagrams/ch3_formal_language_concepts.svg
@@ -7,7 +7,7 @@
   <rect width="1000" height="700" fill="#f8f9fa"/>
   
   <!-- Title -->
-  <text x="500" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="22" font-weight="bold" fill="#1a1a1a">形式言語の基本概念</text>
+  <text x="500" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="22" font-weight="bold" fill="#1a1a1a">形式言語の基本概念</text>
   
   <!-- Main Container -->
   <rect x="20" y="50" width="960" height="630" fill="none" stroke="#e1e5e9" stroke-width="2" rx="10"/>
@@ -15,140 +15,140 @@
   <!-- Section 1: 言語の構成要素 -->
   <g id="language-components">
     <rect x="40" y="80" width="280" height="180" fill="#e3f2fd" stroke="#1976d2" stroke-width="2" rx="8"/>
-    <text x="180" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="16" font-weight="bold" fill="#1976d2">言語の構成要素</text>
+    <text x="180" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="16" font-weight="bold" fill="#1976d2">言語の構成要素</text>
     
     <!-- Alphabet -->
     <rect x="50" y="120" width="80" height="60" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="90" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">アルファベット Σ</text>
-    <text x="90" y="152" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">記号の有限集合</text>
-    <text x="90" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">例: {0,1}, {a,b,c}</text>
-    <text x="90" y="172" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">{漢字}</text>
+    <text x="90" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">アルファベット Σ</text>
+    <text x="90" y="152" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">記号の有限集合</text>
+    <text x="90" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">例: {0,1}, {a,b,c}</text>
+    <text x="90" y="172" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">{漢字}</text>
     
     <!-- String -->
     <rect x="140" y="120" width="80" height="60" fill="#ffffff" stroke="#ff9800" stroke-width="1" rx="4"/>
-    <text x="180" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#ff9800">文字列 w</text>
-    <text x="180" y="152" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">記号の有限列</text>
-    <text x="180" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">長さ |w|</text>
-    <text x="180" y="172" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">空文字列 ε</text>
+    <text x="180" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#ff9800">文字列 w</text>
+    <text x="180" y="152" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">記号の有限列</text>
+    <text x="180" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">長さ |w|</text>
+    <text x="180" y="172" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">空文字列 ε</text>
     
     <!-- Language -->
     <rect x="230" y="120" width="80" height="60" fill="#ffffff" stroke="#4caf50" stroke-width="1" rx="4"/>
-    <text x="270" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#4caf50">言語 L</text>
-    <text x="270" y="152" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">文字列の集合</text>
-    <text x="270" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">L ⊆ Σ*</text>
-    <text x="270" y="172" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">無限集合も可能</text>
+    <text x="270" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#4caf50">言語 L</text>
+    <text x="270" y="152" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">文字列の集合</text>
+    <text x="270" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">L ⊆ Σ*</text>
+    <text x="270" y="172" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">無限集合も可能</text>
   </g>
   
   <!-- Section 2: 文字列の演算 -->
   <g id="string-operations">
     <rect x="340" y="80" width="300" height="180" fill="#fff3e0" stroke="#f57c00" stroke-width="2" rx="8"/>
-    <text x="490" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="16" font-weight="bold" fill="#f57c00">文字列の演算</text>
+    <text x="490" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="16" font-weight="bold" fill="#f57c00">文字列の演算</text>
     
     <!-- Concatenation -->
     <rect x="350" y="120" width="85" height="60" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="392" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">連結 xy</text>
-    <text x="392" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">x の後に y を続ける</text>
-    <text x="392" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">|xy| = |x| + |y|</text>
-    <text x="392" y="167" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">単位元: ε</text>
+    <text x="392" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">連結 xy</text>
+    <text x="392" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">x の後に y を続ける</text>
+    <text x="392" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">|xy| = |x| + |y|</text>
+    <text x="392" y="167" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">単位元: ε</text>
     
     <!-- Power -->
     <rect x="445" y="120" width="85" height="60" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="487" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">べき乗 w<tspan dy="-3" font-size="9">n</tspan></text>
-    <text x="487" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">w<tspan dy="-3" font-size="7">0</tspan><tspan dy="3"> = ε</tspan></text>
-    <text x="487" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">w<tspan dy="-3" font-size="7">n+1</tspan><tspan dy="3"> = w</tspan><tspan dy="-3" font-size="7">n</tspan><tspan dy="3"> w</tspan></text>
-    <text x="487" y="167" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">例: abc<tspan dy="-3" font-size="7">3</tspan><tspan dy="3"> = abcabcabc</tspan></text>
+    <text x="487" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">べき乗 w<tspan dy="-3" font-size="9">n</tspan></text>
+    <text x="487" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">w<tspan dy="-3" font-size="7">0</tspan><tspan dy="3"> = ε</tspan></text>
+    <text x="487" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">w<tspan dy="-3" font-size="7">n+1</tspan><tspan dy="3"> = w</tspan><tspan dy="-3" font-size="7">n</tspan><tspan dy="3"> w</tspan></text>
+    <text x="487" y="167" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">例: abc<tspan dy="-3" font-size="7">3</tspan><tspan dy="3"> = abcabcabc</tspan></text>
     
     <!-- Reverse -->
     <rect x="540" y="120" width="85" height="60" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="582" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">逆転 w<tspan dy="-3" font-size="9">R</tspan></text>
-    <text x="582" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">w = a<tspan dy="3" font-size="7">1</tspan><tspan dy="-3">a</tspan><tspan dy="3" font-size="7">2</tspan><tspan dy="-3">...a</tspan><tspan dy="3" font-size="7">n</tspan></text>
-    <text x="582" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">w<tspan dy="-3" font-size="7">R</tspan><tspan dy="3"> = a</tspan><tspan dy="3" font-size="7">n</tspan><tspan dy="-3">...a</tspan><tspan dy="3" font-size="7">2</tspan><tspan dy="-3">a</tspan><tspan dy="3" font-size="7">1</tspan></text>
-    <text x="582" y="167" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">例: abc<tspan dy="-3" font-size="7">R</tspan><tspan dy="3"> = cba</tspan></text>
+    <text x="582" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">逆転 w<tspan dy="-3" font-size="9">R</tspan></text>
+    <text x="582" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">w = a<tspan dy="3" font-size="7">1</tspan><tspan dy="-3">a</tspan><tspan dy="3" font-size="7">2</tspan><tspan dy="-3">...a</tspan><tspan dy="3" font-size="7">n</tspan></text>
+    <text x="582" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">w<tspan dy="-3" font-size="7">R</tspan><tspan dy="3"> = a</tspan><tspan dy="3" font-size="7">n</tspan><tspan dy="-3">...a</tspan><tspan dy="3" font-size="7">2</tspan><tspan dy="-3">a</tspan><tspan dy="3" font-size="7">1</tspan></text>
+    <text x="582" y="167" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">例: abc<tspan dy="-3" font-size="7">R</tspan><tspan dy="3"> = cba</tspan></text>
   </g>
   
   <!-- Section 3: 言語の演算 -->
   <g id="language-operations">
     <rect x="660" y="80" width="300" height="180" fill="#e8f5e8" stroke="#388e3c" stroke-width="2" rx="8"/>
-    <text x="810" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="16" font-weight="bold" fill="#388e3c">言語の演算</text>
+    <text x="810" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="16" font-weight="bold" fill="#388e3c">言語の演算</text>
     
     <!-- Union -->
     <rect x="670" y="120" width="70" height="60" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="705" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">L<tspan dy="3" font-size="9">1</tspan><tspan dy="-3"> ∪ L</tspan><tspan dy="3" font-size="9">2</tspan></text>
-    <text x="705" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">和集合</text>
-    <text x="705" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">「または」</text>
+    <text x="705" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">L<tspan dy="3" font-size="9">1</tspan><tspan dy="-3"> ∪ L</tspan><tspan dy="3" font-size="9">2</tspan></text>
+    <text x="705" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">和集合</text>
+    <text x="705" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">「または」</text>
     
     <!-- Concatenation -->
     <rect x="750" y="120" width="70" height="60" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="785" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">L<tspan dy="3" font-size="9">1</tspan><tspan dy="-3"> L</tspan><tspan dy="3" font-size="9">2</tspan></text>
-    <text x="785" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">連結</text>
-    <text x="785" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">{xy | x ∈ L<tspan dy="3" font-size="7">1</tspan><tspan dy="-3">, y ∈ L</tspan><tspan dy="3" font-size="7">2</tspan><tspan dy="-3">}</tspan></text>
+    <text x="785" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">L<tspan dy="3" font-size="9">1</tspan><tspan dy="-3"> L</tspan><tspan dy="3" font-size="9">2</tspan></text>
+    <text x="785" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">連結</text>
+    <text x="785" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">{xy | x ∈ L<tspan dy="3" font-size="7">1</tspan><tspan dy="-3">, y ∈ L</tspan><tspan dy="3" font-size="7">2</tspan><tspan dy="-3">}</tspan></text>
     
     <!-- Kleene Closure -->
     <rect x="830" y="120" width="70" height="60" fill="#ffffff" stroke="#9c27b0" stroke-width="1" rx="4"/>
-    <text x="865" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#9c27b0">L*</text>
-    <text x="865" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">クリーネ閉包</text>
-    <text x="865" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">0回以上の連結</text>
-    <text x="865" y="167" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">L* = ⋃<tspan dy="3" font-size="7">n</tspan><tspan dy="-3"> L</tspan><tspan dy="-3" font-size="7">n</tspan></text>
+    <text x="865" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#9c27b0">L*</text>
+    <text x="865" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">クリーネ閉包</text>
+    <text x="865" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">0回以上の連結</text>
+    <text x="865" y="167" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">L* = ⋃<tspan dy="3" font-size="7">n</tspan><tspan dy="-3"> L</tspan><tspan dy="-3" font-size="7">n</tspan></text>
     
     <!-- Positive Closure -->
     <rect x="910" y="120" width="40" height="60" fill="#ffffff" stroke="#9c27b0" stroke-width="1" rx="4"/>
-    <text x="930" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#9c27b0">L<tspan dy="-3" font-size="9">+</tspan></text>
-    <text x="930" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">正閉包</text>
-    <text x="930" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">1回以上</text>
-    <text x="930" y="167" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">の連結</text>
+    <text x="930" y="135" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#9c27b0">L<tspan dy="-3" font-size="9">+</tspan></text>
+    <text x="930" y="147" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">正閉包</text>
+    <text x="930" y="157" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">1回以上</text>
+    <text x="930" y="167" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">の連結</text>
   </g>
   
   <!-- Section 4: Example -->
   <g id="example">
     <rect x="40" y="290" width="920" height="140" fill="#ffe0b2" stroke="#f57c00" stroke-width="2" rx="8"/>
-    <text x="500" y="315" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="16" font-weight="bold" fill="#f57c00">例: L = {0, 11}</text>
+    <text x="500" y="315" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="16" font-weight="bold" fill="#f57c00">例: L = {0, 11}</text>
     
-    <text x="80" y="340" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">演算例:</text>
+    <text x="80" y="340" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">演算例:</text>
     
-    <text x="80" y="365" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">L<tspan dy="-3" font-size="10">2</tspan><tspan dy="3"> = {00, 011, 110, 1111}</tspan></text>
+    <text x="80" y="365" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">L<tspan dy="-3" font-size="10">2</tspan><tspan dy="3"> = {00, 011, 110, 1111}</tspan></text>
     
-    <text x="80" y="385" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">L* = {ε, 0, 11, 00, 011, 110, 1111, 000, 0011, 0110, ...}</text>
+    <text x="80" y="385" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">L* = {ε, 0, 11, 00, 011, 110, 1111, 000, 0011, 0110, ...}</text>
     
-    <text x="80" y="405" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">L<tspan dy="-3" font-size="10">+</tspan><tspan dy="3"> = {0, 11, 00, 011, 110, 1111, 000, 0011, 0110, ...}</tspan></text>
+    <text x="80" y="405" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">L<tspan dy="-3" font-size="10">+</tspan><tspan dy="3"> = {0, 11, 00, 011, 110, 1111, 000, 0011, 0110, ...}</tspan></text>
   </g>
   
   <!-- Key Mathematical Properties -->
   <g id="properties">
     <rect x="40" y="450" width="920" height="220" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="2" rx="8"/>
-    <text x="500" y="475" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="16" font-weight="bold" fill="#7b1fa2">重要な性質</text>
+    <text x="500" y="475" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="16" font-weight="bold" fill="#7b1fa2">重要な性質</text>
     
     <!-- Concatenation Properties -->
     <g id="concat-properties">
-      <text x="80" y="505" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">連結の性質:</text>
-      <text x="100" y="525" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• 結合的: (xy)z = x(yz)</text>
-      <text x="100" y="540" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• 単位元: xε = εx = x</text>
-      <text x="100" y="555" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• 非可換: xy ≠ yx (一般に)</text>
+      <text x="80" y="505" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">連結の性質:</text>
+      <text x="100" y="525" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• 結合的: (xy)z = x(yz)</text>
+      <text x="100" y="540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• 単位元: xε = εx = x</text>
+      <text x="100" y="555" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• 非可換: xy ≠ yx (一般に)</text>
     </g>
     
     <!-- Closure Properties -->
     <g id="closure-properties">
-      <text x="400" y="505" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">閉包の性質:</text>
-      <text x="420" y="525" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• L<tspan dy="-3" font-size="10">0</tspan><tspan dy="3"> = {ε}</tspan></text>
-      <text x="420" y="540" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• L<tspan dy="-3" font-size="10">+</tspan><tspan dy="3"> = LL*</tspan></text>
-      <text x="420" y="555" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• L* = L<tspan dy="-3" font-size="10">+</tspan><tspan dy="3"> ∪ {ε}</tspan></text>
+      <text x="400" y="505" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">閉包の性質:</text>
+      <text x="420" y="525" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• L<tspan dy="-3" font-size="10">0</tspan><tspan dy="3"> = {ε}</tspan></text>
+      <text x="420" y="540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• L<tspan dy="-3" font-size="10">+</tspan><tspan dy="3"> = LL*</tspan></text>
+      <text x="420" y="555" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• L* = L<tspan dy="-3" font-size="10">+</tspan><tspan dy="3"> ∪ {ε}</tspan></text>
     </g>
     
     <!-- Alphabet Relations -->
     <g id="alphabet-relations">
-      <text x="80" y="590" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">アルファベットと集合の関係:</text>
-      <text x="100" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• Σ<tspan dy="-3" font-size="10">*</tspan><tspan dy="3">: Σ上のすべての文字列の集合</tspan></text>
-      <text x="100" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• Σ<tspan dy="-3" font-size="10">+</tspan><tspan dy="3">: Σ上の空でない文字列の集合</tspan></text>
-      <text x="100" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• Σ<tspan dy="-3" font-size="10">n</tspan><tspan dy="3">: 長さnの文字列の集合</tspan></text>
-      <text x="100" y="655" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• |Σ<tspan dy="-3" font-size="10">n</tspan><tspan dy="3">| = |Σ|</tspan><tspan dy="-3" font-size="10">n</tspan></text>
+      <text x="80" y="590" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">アルファベットと集合の関係:</text>
+      <text x="100" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• Σ<tspan dy="-3" font-size="10">*</tspan><tspan dy="3">: Σ上のすべての文字列の集合</tspan></text>
+      <text x="100" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• Σ<tspan dy="-3" font-size="10">+</tspan><tspan dy="3">: Σ上の空でない文字列の集合</tspan></text>
+      <text x="100" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• Σ<tspan dy="-3" font-size="10">n</tspan><tspan dy="3">: 長さnの文字列の集合</tspan></text>
+      <text x="100" y="655" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• |Σ<tspan dy="-3" font-size="10">n</tspan><tspan dy="3">| = |Σ|</tspan><tspan dy="-3" font-size="10">n</tspan></text>
     </g>
     
     <!-- Language Operations Properties -->
     <g id="language-ops-properties">
-      <text x="500" y="590" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">言語演算の性質:</text>
-      <text x="520" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• 和集合、積集合は可換、結合的</text>
-      <text x="520" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• 分配法則: L<tspan dy="3" font-size="10">1</tspan><tspan dy="-3">(L</tspan><tspan dy="3" font-size="10">2</tspan><tspan dy="-3"> ∪ L</tspan><tspan dy="3" font-size="10">3</tspan><tspan dy="-3">) = L</tspan><tspan dy="3" font-size="10">1</tspan><tspan dy="-3">L</tspan><tspan dy="3" font-size="10">2</tspan><tspan dy="-3"> ∪ L</tspan><tspan dy="3" font-size="10">1</tspan><tspan dy="-3">L</tspan><tspan dy="3" font-size="10">3</tspan></text>
-      <text x="520" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• De Morganの法則: (L<tspan dy="3" font-size="10">1</tspan><tspan dy="-3"> ∪ L</tspan><tspan dy="3" font-size="10">2</tspan><tspan dy="-3">)ᶜ = L</tspan><tspan dy="3" font-size="10">1</tspan><tspan dy="-3">ᶜ ∩ L</tspan><tspan dy="3" font-size="10">2</tspan><tspan dy="-3">ᶜ</tspan></text>
-      <text x="520" y="655" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">• 吸収法則: L ∪ ∅ = L, L ∩ Σ* = L</text>
+      <text x="500" y="590" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">言語演算の性質:</text>
+      <text x="520" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• 和集合、積集合は可換、結合的</text>
+      <text x="520" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• 分配法則: L<tspan dy="3" font-size="10">1</tspan><tspan dy="-3">(L</tspan><tspan dy="3" font-size="10">2</tspan><tspan dy="-3"> ∪ L</tspan><tspan dy="3" font-size="10">3</tspan><tspan dy="-3">) = L</tspan><tspan dy="3" font-size="10">1</tspan><tspan dy="-3">L</tspan><tspan dy="3" font-size="10">2</tspan><tspan dy="-3"> ∪ L</tspan><tspan dy="3" font-size="10">1</tspan><tspan dy="-3">L</tspan><tspan dy="3" font-size="10">3</tspan></text>
+      <text x="520" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• De Morganの法則: (L<tspan dy="3" font-size="10">1</tspan><tspan dy="-3"> ∪ L</tspan><tspan dy="3" font-size="10">2</tspan><tspan dy="-3">)ᶜ = L</tspan><tspan dy="3" font-size="10">1</tspan><tspan dy="-3">ᶜ ∩ L</tspan><tspan dy="3" font-size="10">2</tspan><tspan dy="-3">ᶜ</tspan></text>
+      <text x="520" y="655" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">• 吸収法則: L ∪ ∅ = L, L ∩ Σ* = L</text>
     </g>
   </g>
 </svg>

--- a/docs/assets/images/diagrams/ch3_formal_language_hierarchy.svg
+++ b/docs/assets/images/diagrams/ch3_formal_language_hierarchy.svg
@@ -12,11 +12,11 @@
       .concept-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -24,7 +24,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -32,7 +32,7 @@
       }
       
       .concept-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 13px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -40,7 +40,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -48,7 +48,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -56,7 +56,7 @@
       }
       
       .example { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch3_myhill_nerode_prefix_distinguish.svg
+++ b/docs/assets/images/diagrams/ch3_myhill_nerode_prefix_distinguish.svg
@@ -6,7 +6,7 @@
 
   <defs>
     <style>
-      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
+      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
       .small-text { font-size: 12px; }
       .large-text { font-size: 16px; font-weight: bold; }
       .box { fill: #ffffff; stroke: #495057; stroke-width: 1.5; rx: 8; }

--- a/docs/assets/images/diagrams/ch3_pda_acceptance_modes.svg
+++ b/docs/assets/images/diagrams/ch3_pda_acceptance_modes.svg
@@ -4,7 +4,7 @@
   <desc id="desc">左に最終状態受理（受理状態への到達）、右に空スタック受理（スタックが空になる）の模式図。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .panel { fill: #f8f9fa; stroke: #dee2e6; }
       .state { fill: #fff; stroke: #495057; stroke-width: 1.6; }
       .accept { fill: #e6fcf5; stroke: #12b886; }

--- a/docs/assets/images/diagrams/ch3_pda_stack_operation.svg
+++ b/docs/assets/images/diagrams/ch3_pda_stack_operation.svg
@@ -4,7 +4,7 @@
   <desc id="desc">入力列に対し、PDA がスタックにプッシュ/ポップして括弧の整合を確認する様子を段階的に示す模式図。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .box { fill: #f8f9fa; stroke: #adb5bd; stroke-width: 1.5; }
       .state { fill: #fff; stroke: #495057; stroke-width: 1.5; }
       .accept { fill: #e6fcf5; }

--- a/docs/assets/images/diagrams/ch3_pumping_lemma_limitations.svg
+++ b/docs/assets/images/diagrams/ch3_pumping_lemma_limitations.svg
@@ -7,7 +7,7 @@
   <rect width="1200" height="900" fill="#f8f9fa"/>
   
   <!-- Title -->
-  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="24" font-weight="bold" fill="#1a1a1a">正規言語のPumping補題と限界</text>
+  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="24" font-weight="bold" fill="#1a1a1a">正規言語のPumping補題と限界</text>
   
   <!-- Main Container -->
   <rect x="20" y="50" width="1160" height="830" fill="none" stroke="#e1e5e9" stroke-width="2" rx="10"/>
@@ -15,215 +15,215 @@
   <!-- Section 1: Pumping Lemma Statement -->
   <g id="pumping-statement">
     <rect x="40" y="80" width="560" height="200" fill="#fff3e0" stroke="#f57c00" stroke-width="2" rx="8"/>
-    <text x="320" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#f57c00">Pumping補題の内容</text>
+    <text x="320" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#f57c00">Pumping補題の内容</text>
     
     <!-- Statement -->
     <rect x="60" y="120" width="200" height="140" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="160" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">正規言語Lに対し</text>
-    <text x="70" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">pumping length pが存在</text>
-    <text x="70" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">|s| ≥ pなs ∈ Lに対し</text>
-    <text x="70" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">s = xyzと分解可能</text>
-    <text x="70" y="210" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">ここで:</text>
-    <text x="70" y="225" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• x: 前部分</text>
-    <text x="70" y="240" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• y: ループ部分</text>
-    <text x="70" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">• z: 後部分</text>
+    <text x="160" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">正規言語Lに対し</text>
+    <text x="70" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">pumping length pが存在</text>
+    <text x="70" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">|s| ≥ pなs ∈ Lに対し</text>
+    <text x="70" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">s = xyzと分解可能</text>
+    <text x="70" y="210" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">ここで:</text>
+    <text x="70" y="225" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• x: 前部分</text>
+    <text x="70" y="240" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• y: ループ部分</text>
+    <text x="70" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">• z: 後部分</text>
     
     <!-- Conditions -->
     <rect x="270" y="120" width="150" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="345" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">条件</text>
-    <text x="280" y="165" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#d32f2f">1. |xy| ≤ p</text>
-    <text x="290" y="180" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">ループは最初のp文字以内</text>
-    <text x="280" y="200" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#d32f2f">2. |y| &gt; 0</text>
-    <text x="290" y="215" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">ループ部分は空でない</text>
-    <text x="280" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#d32f2f">3. ∀i ≥ 0, xy<tspan dy="-3" font-size="11">i</tspan><tspan dy="3">z ∈ L</tspan></text>
-    <text x="290" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">任意回数の繰り返しが可能</text>
+    <text x="345" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">条件</text>
+    <text x="280" y="165" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#d32f2f">1. |xy| ≤ p</text>
+    <text x="290" y="180" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">ループは最初のp文字以内</text>
+    <text x="280" y="200" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#d32f2f">2. |y| &gt; 0</text>
+    <text x="290" y="215" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">ループ部分は空でない</text>
+    <text x="280" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#d32f2f">3. ∀i ≥ 0, xy<tspan dy="-3" font-size="11">i</tspan><tspan dy="3">z ∈ L</tspan></text>
+    <text x="290" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">任意回数の繰り返しが可能</text>
     
     <!-- Intuition -->
     <rect x="430" y="120" width="160" height="140" fill="#ffffff" stroke="#4caf50" stroke-width="1" rx="4"/>
-    <text x="510" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#4caf50">直観的理解</text>
-    <text x="440" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 長い文字列にはループが</text>
-    <text x="440" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">　存在する</text>
-    <text x="440" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• ループ部分は繰り返し</text>
-    <text x="440" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">　可能</text>
-    <text x="440" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 鳩の巣原理の応用</text>
-    <text x="440" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 有限状態の制約</text>
+    <text x="510" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#4caf50">直観的理解</text>
+    <text x="440" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 長い文字列にはループが</text>
+    <text x="440" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">　存在する</text>
+    <text x="440" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• ループ部分は繰り返し</text>
+    <text x="440" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">　可能</text>
+    <text x="440" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 鳩の巣原理の応用</text>
+    <text x="440" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 有限状態の制約</text>
     
   </g>
   
   <!-- Section 2: Proof Outline -->
   <g id="proof-outline">
     <rect x="620" y="80" width="540" height="200" fill="#e3f2fd" stroke="#1976d2" stroke-width="2" rx="8"/>
-    <text x="890" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#1976d2">証明の概略</text>
+    <text x="890" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#1976d2">証明の概略</text>
     
     <!-- DFA Based -->
     <rect x="640" y="120" width="120" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="700" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">正規言語→DFA</text>
-    <text x="650" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">存在</text>
-    <text x="650" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">状態数をpとする</text>
-    <text x="650" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">|s| ≥ pなら</text>
-    <text x="650" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">状態重複必発</text>
+    <text x="700" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">正規言語→DFA</text>
+    <text x="650" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">存在</text>
+    <text x="650" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">状態数をpとする</text>
+    <text x="650" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">|s| ≥ pなら</text>
+    <text x="650" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">状態重複必発</text>
     
     <!-- State Sequence -->
     <rect x="770" y="120" width="130" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="835" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">状態列</text>
-    <text x="780" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">r₀, r₁, ..., rₚ</text>
-    <text x="780" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">鳩の巣原理で</text>
-    <text x="780" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">rⱼ = rₖ</text>
-    <text x="780" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">0 ≤ j &lt; k ≤ p</text>
+    <text x="835" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">状態列</text>
+    <text x="780" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">r₀, r₁, ..., rₚ</text>
+    <text x="780" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">鳩の巣原理で</text>
+    <text x="780" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">rⱼ = rₖ</text>
+    <text x="780" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">0 ≤ j &lt; k ≤ p</text>
     
     <!-- Decomposition -->
     <rect x="910" y="120" width="120" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="970" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">分解の構成</text>
-    <text x="920" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">x = a₁...aⱼ</text>
-    <text x="920" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">y = aⱼ₊₁...aₖ</text>
-    <text x="920" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">z = aₖ₊₁...aₙ</text>
+    <text x="970" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">分解の構成</text>
+    <text x="920" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">x = a₁...aⱼ</text>
+    <text x="920" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">y = aⱼ₊₁...aₖ</text>
+    <text x="920" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">z = aₖ₊₁...aₙ</text>
     
     <!-- Loop Characteristics -->
     <rect x="1040" y="120" width="110" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="1095" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">ループの特徴</text>
-    <text x="1050" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">y部分は状態</text>
-    <text x="1050" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">ループを形成</text>
-    <text x="1050" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">任意回数</text>
-    <text x="1050" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">繰り返し可能</text>
+    <text x="1095" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">ループの特徴</text>
+    <text x="1050" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">y部分は状態</text>
+    <text x="1050" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">ループを形成</text>
+    <text x="1050" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">任意回数</text>
+    <text x="1050" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">繰り返し可能</text>
   </g>
   
   <!-- Section 3: Visual Proof -->
   <g id="visual-proof">
     <rect x="40" y="300" width="1120" height="180" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="2" rx="8"/>
-    <text x="600" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#7b1fa2">視覚的証明: DFAでの状態遷移</text>
+    <text x="600" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#7b1fa2">視覚的証明: DFAでの状態遷移</text>
     
     <!-- String Representation -->
-    <text x="80" y="355" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">文字列 s = a₁a₂a₃...aⱼaⱼ₊₁...aₖaₖ₊₁...aₙ (|s| ≥ p)</text>
+    <text x="80" y="355" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">文字列 s = a₁a₂a₃...aⱼaⱼ₊₁...aₖaₖ₊₁...aₙ (|s| ≥ p)</text>
     
     <!-- String parts -->
     <g id="string-parts">
       <rect x="80" y="370" width="150" height="25" fill="#ffcdd2" stroke="#d32f2f" stroke-width="1" rx="3"/>
-      <text x="155" y="387" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#d32f2f">x = a₁...aⱼ</text>
+      <text x="155" y="387" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#d32f2f">x = a₁...aⱼ</text>
       
       <rect x="240" y="370" width="120" height="25" fill="#c8e6c9" stroke="#388e3c" stroke-width="1" rx="3"/>
-      <text x="300" y="387" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">y = aⱼ₊₁...aₖ</text>
+      <text x="300" y="387" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">y = aⱼ₊₁...aₖ</text>
       
       <rect x="370" y="370" width="150" height="25" fill="#bbdefb" stroke="#1976d2" stroke-width="1" rx="3"/>
-      <text x="445" y="387" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">z = aₖ₊₁...aₙ</text>
+      <text x="445" y="387" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">z = aₖ₊₁...aₙ</text>
     </g>
     
     <!-- State sequence -->
-    <text x="80" y="420" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">状態遷移: </text>
+    <text x="80" y="420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">状態遷移: </text>
     
     <!-- States -->
     <g id="state-sequence">
       <circle cx="200" cy="440" r="15" fill="#ffffff" stroke="#333" stroke-width="2"/>
-      <text x="200" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#333">q₀</text>
-      <text x="200" y="465" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">初期</text>
+      <text x="200" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#333">q₀</text>
+      <text x="200" y="465" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">初期</text>
       
       <path d="M 215 440 L 265 440" fill="none" stroke="#d32f2f" stroke-width="2" marker-end="url(#arrowhead-red)"/>
-      <text x="240" y="435" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#d32f2f">x</text>
+      <text x="240" y="435" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#d32f2f">x</text>
       
       <circle cx="280" cy="440" r="15" fill="#ffffff" stroke="#388e3c" stroke-width="2"/>
-      <text x="280" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#388e3c">rⱼ</text>
-      <text x="280" y="465" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">重複1</text>
+      <text x="280" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#388e3c">rⱼ</text>
+      <text x="280" y="465" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">重複1</text>
       
       <path d="M 295 440 L 345 440" fill="none" stroke="#388e3c" stroke-width="2" marker-end="url(#arrowhead-green)"/>
-      <text x="320" y="435" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#388e3c">y</text>
+      <text x="320" y="435" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#388e3c">y</text>
       
       <circle cx="360" cy="440" r="15" fill="#ffffff" stroke="#388e3c" stroke-width="2"/>
-      <text x="360" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#388e3c">rₖ</text>
-      <text x="360" y="465" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">重複2</text>
+      <text x="360" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#388e3c">rₖ</text>
+      <text x="360" y="465" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">重複2</text>
       
       <path d="M 375 440 L 425 440" fill="none" stroke="#1976d2" stroke-width="2" marker-end="url(#arrowhead-blue)"/>
-      <text x="400" y="435" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#1976d2">z</text>
+      <text x="400" y="435" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#1976d2">z</text>
       
       <circle cx="440" cy="440" r="15" fill="#ffffff" stroke="#1976d2" stroke-width="2"/>
       <circle cx="440" cy="440" r="10" fill="none" stroke="#1976d2" stroke-width="1"/>
-      <text x="440" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#1976d2">qf</text>
-      <text x="440" y="465" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">受理</text>
+      <text x="440" y="445" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#1976d2">qf</text>
+      <text x="440" y="465" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">受理</text>
       
       <!-- Loop indication -->
       <path d="M 350 425 Q 320 400 290 425" fill="none" stroke="#388e3c" stroke-width="2" stroke-dasharray="3,2" marker-end="url(#arrowhead-green)"/>
-      <text x="320" y="408" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#388e3c">rⱼ = rₖ ループ</text>
+      <text x="320" y="408" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#388e3c">rⱼ = rₖ ループ</text>
     </g>
     
     <!-- Pumping illustration -->
-    <text x="600" y="420" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">Pumping: xy<tspan dy="-3" font-size="12">i</tspan><tspan dy="3">z ∈ L</tspan></text>
+    <text x="600" y="420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">Pumping: xy<tspan dy="-3" font-size="12">i</tspan><tspan dy="3">z ∈ L</tspan></text>
     
     <g id="pumping-examples">
-      <text x="620" y="445" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">i = 0: xz (yを削除)</text>
-      <text x="620" y="460" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">i = 1: xyz (元の文字列)</text>
-      <text x="620" y="475" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#555">i = 2: xyyyz (yを2回繰り返し)</text>
+      <text x="620" y="445" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">i = 0: xz (yを削除)</text>
+      <text x="620" y="460" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">i = 1: xyz (元の文字列)</text>
+      <text x="620" y="475" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#555">i = 2: xyyyz (yを2回繰り返し)</text>
     </g>
   </g>
   
   <!-- Section 4: Non-regular Language Examples -->
   <g id="non-regular-examples">
     <rect x="40" y="500" width="1120" height="180" fill="#ffebee" stroke="#d32f2f" stroke-width="2" rx="8"/>
-    <text x="600" y="525" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#d32f2f">非正規言語の例</text>
+    <text x="600" y="525" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#d32f2f">非正規言語の例</text>
     
     <!-- Example 1 -->
     <rect x="60" y="540" width="340" height="120" fill="#ffffff" stroke="#d32f2f" stroke-width="1" rx="4"/>
-    <text x="230" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#d32f2f">{0ⁿ1ⁿ | n ≥ 0}</text>
-    <text x="70" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">証明:</text>
-    <text x="80" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">s = 0ᵖ1ᵖを考える</text>
-    <text x="80" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">|xy| ≤ pより、yは0のみから構成</text>
-    <text x="80" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">xy²z = 0ᵖ⁺ᵏ1ᵖ ∉ Lとなり矛盾</text>
-    <text x="80" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">∴ この言語は非正規</text>
+    <text x="230" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#d32f2f">{0ⁿ1ⁿ | n ≥ 0}</text>
+    <text x="70" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">証明:</text>
+    <text x="80" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">s = 0ᵖ1ᵖを考える</text>
+    <text x="80" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">|xy| ≤ pより、yは0のみから構成</text>
+    <text x="80" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">xy²z = 0ᵖ⁺ᵏ1ᵖ ∉ Lとなり矛盾</text>
+    <text x="80" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">∴ この言語は非正規</text>
     
     <!-- Example 2 -->
     <rect x="420" y="540" width="340" height="120" fill="#ffffff" stroke="#d32f2f" stroke-width="1" rx="4"/>
-    <text x="590" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#d32f2f">{ww | w ∈ {0,1}*}</text>
-    <text x="430" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">証明の概略:</text>
-    <text x="440" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">前半部でpumpingすると</text>
-    <text x="440" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">後半部と不一致になる</text>
-    <text x="440" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">具体的構成は技術的</text>
-    <text x="440" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">∴ この言語は非正規</text>
+    <text x="590" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#d32f2f">{ww | w ∈ {0,1}*}</text>
+    <text x="430" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">証明の概略:</text>
+    <text x="440" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">前半部でpumpingすると</text>
+    <text x="440" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">後半部と不一致になる</text>
+    <text x="440" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">具体的構成は技術的</text>
+    <text x="440" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">∴ この言語は非正規</text>
     
     <!-- Example 3 -->
     <rect x="780" y="540" width="360" height="120" fill="#ffffff" stroke="#d32f2f" stroke-width="1" rx="4"/>
-    <text x="960" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#d32f2f">{0ⁿ² | n ≥ 0}</text>
-    <text x="790" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">証明:</text>
-    <text x="800" y="595" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">平方数の間隔は等差数列でない</text>
-    <text x="800" y="610" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">pumpingによる等間隔増加と矛盾</text>
-    <text x="800" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">詳細は数論的議論が必要</text>
-    <text x="800" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">∴ この言語は非正規</text>
+    <text x="960" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#d32f2f">{0ⁿ² | n ≥ 0}</text>
+    <text x="790" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">証明:</text>
+    <text x="800" y="595" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">平方数の間隔は等差数列でない</text>
+    <text x="800" y="610" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">pumpingによる等間隔増加と矛盾</text>
+    <text x="800" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">詳細は数論的議論が必要</text>
+    <text x="800" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">∴ この言語は非正規</text>
   </g>
   
   <!-- Section 5: Myhill-Nerode Theorem -->
   <g id="myhill-nerode">
     <rect x="40" y="700" width="1120" height="160" fill="#e8f5e8" stroke="#388e3c" stroke-width="2" rx="8"/>
-    <text x="600" y="725" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#388e3c">Myhill-Nerodeの定理</text>
+    <text x="600" y="725" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#388e3c">Myhill-Nerodeの定理</text>
     
     <!-- Theorem Statement -->
     <rect x="60" y="740" width="280" height="105" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="200" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">正規言語の特徴付け</text>
-    <text x="200" y="785" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">Lが正規 ⇔ 右同値類が有限</text>
-    <text x="70" y="805" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">この定理により正規性を</text>
-    <text x="70" y="820" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">代数的に特徴付けできる</text>
-    <text x="70" y="835" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">最小DFAの状態数も決定される</text>
+    <text x="200" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">正規言語の特徴付け</text>
+    <text x="200" y="785" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">Lが正規 ⇔ 右同値類が有限</text>
+    <text x="70" y="805" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">この定理により正規性を</text>
+    <text x="70" y="820" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">代数的に特徴付けできる</text>
+    <text x="70" y="835" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">最小DFAの状態数も決定される</text>
     
     <!-- Right Congruence -->
     <rect x="360" y="740" width="280" height="105" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="500" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">右同値関係</text>
-    <text x="500" y="785" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#333">x ≡ₗ y ⇔ ∀z, xz ∈ L ⇔ yz ∈ L</text>
-    <text x="370" y="805" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">「区別不可能」な文字列</text>
-    <text x="370" y="820" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">同じ受理・拒否パターン</text>
-    <text x="370" y="835" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">DFAの状態に対応</text>
+    <text x="500" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">右同値関係</text>
+    <text x="500" y="785" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#333">x ≡ₗ y ⇔ ∀z, xz ∈ L ⇔ yz ∈ L</text>
+    <text x="370" y="805" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">「区別不可能」な文字列</text>
+    <text x="370" y="820" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">同じ受理・拒否パターン</text>
+    <text x="370" y="835" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">DFAの状態に対応</text>
     
     <!-- Applications -->
     <rect x="660" y="740" width="220" height="105" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="770" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">応用</text>
-    <text x="670" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 最小状態数の下界</text>
-    <text x="670" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• DFA最小化の理論</text>
-    <text x="670" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 正規性の判定</text>
-    <text x="670" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 等価性の証明</text>
-    <text x="670" y="840" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 計算複雑性解析</text>
+    <text x="770" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">応用</text>
+    <text x="670" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 最小状態数の下界</text>
+    <text x="670" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• DFA最小化の理論</text>
+    <text x="670" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 正規性の判定</text>
+    <text x="670" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 等価性の証明</text>
+    <text x="670" y="840" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 計算複雑性解析</text>
     
     <!-- Concrete Example -->
     <rect x="900" y="740" width="240" height="105" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="1020" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">具体例: {0ⁿ1ⁿ | n ≥ 0}</text>
-    <text x="910" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">0ⁱと0ʲ (i ≠ j)は区別可能:</text>
-    <text x="910" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">z = 1ⁱに対し 0ⁱ1ⁱ ∈ L だが</text>
-    <text x="910" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">0ʲ1ⁱ ∉ L (i ≠ j)</text>
-    <text x="910" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">∴ 無限個の同値類が存在</text>
-    <text x="910" y="840" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">→ 非正規言語</text>
+    <text x="1020" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">具体例: {0ⁿ1ⁿ | n ≥ 0}</text>
+    <text x="910" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">0ⁱと0ʲ (i ≠ j)は区別可能:</text>
+    <text x="910" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">z = 1ⁱに対し 0ⁱ1ⁱ ∈ L だが</text>
+    <text x="910" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">0ʲ1ⁱ ∉ L (i ≠ j)</text>
+    <text x="910" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">∴ 無限個の同値類が存在</text>
+    <text x="910" y="840" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">→ 非正規言語</text>
   </g>
   
   <!-- Arrow markers -->

--- a/docs/assets/images/diagrams/ch3_pushdown_automata_structure.svg
+++ b/docs/assets/images/diagrams/ch3_pushdown_automata_structure.svg
@@ -7,7 +7,7 @@
   <rect width="1200" height="900" fill="#f8f9fa"/>
   
   <!-- Title -->
-  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="24" font-weight="bold" fill="#1a1a1a">プッシュダウンオートマトンの構造と機能</text>
+  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="24" font-weight="bold" fill="#1a1a1a">プッシュダウンオートマトンの構造と機能</text>
   
   <!-- Main Container -->
   <rect x="20" y="50" width="1160" height="830" fill="none" stroke="#e1e5e9" stroke-width="2" rx="10"/>
@@ -15,219 +15,219 @@
   <!-- Section 1: PDA Basic Structure -->
   <g id="pda-structure">
     <rect x="40" y="80" width="560" height="220" fill="#e3f2fd" stroke="#1976d2" stroke-width="2" rx="8"/>
-    <text x="320" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#1976d2">PDAの基本構造</text>
+    <text x="320" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#1976d2">PDAの基本構造</text>
     
     <!-- PDA Definition -->
     <rect x="60" y="120" width="220" height="160" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="170" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">P = (Q, Σ, Γ, δ, q₀, Z₀, F)</text>
-    <text x="70" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• Q: 状態集合</text>
-    <text x="70" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• Σ: 入力アルファベット</text>
-    <text x="70" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• Γ: スタックアルファベット</text>
-    <text x="70" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• δ: Q×(Σ∪{ε})×Γ → P_finite(Q×Γ*)</text>
-    <text x="70" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• q₀: 初期状態</text>
-    <text x="70" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• Z₀: 初期スタック記号</text>
-    <text x="70" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• F: 受理状態集合</text>
-    <text x="70" y="270" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">P_finiteは有限部分集合のみ</text>
+    <text x="170" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">P = (Q, Σ, Γ, δ, q₀, Z₀, F)</text>
+    <text x="70" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• Q: 状態集合</text>
+    <text x="70" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• Σ: 入力アルファベット</text>
+    <text x="70" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• Γ: スタックアルファベット</text>
+    <text x="70" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• δ: Q×(Σ∪{ε})×Γ → P_finite(Q×Γ*)</text>
+    <text x="70" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• q₀: 初期状態</text>
+    <text x="70" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• Z₀: 初期スタック記号</text>
+    <text x="70" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• F: 受理状態集合</text>
+    <text x="70" y="270" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">P_finiteは有限部分集合のみ</text>
     
     <!-- Components -->
     <rect x="290" y="120" width="150" height="160" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="365" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">構成要素</text>
-    <text x="300" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 有限制御部(状態)</text>
-    <text x="310" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">現在の制御状態</text>
-    <text x="300" y="195" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 入力テープ(読み取り専用)</text>
-    <text x="310" y="210" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">左から右へ一方向</text>
-    <text x="300" y="230" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• スタック(無限記憶域)</text>
-    <text x="310" y="245" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">LIFO構造</text>
-    <text x="310" y="260" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">無限の記憶容量</text>
+    <text x="365" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">構成要素</text>
+    <text x="300" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 有限制御部(状態)</text>
+    <text x="310" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">現在の制御状態</text>
+    <text x="300" y="195" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 入力テープ(読み取り専用)</text>
+    <text x="310" y="210" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">左から右へ一方向</text>
+    <text x="300" y="230" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• スタック(無限記憶域)</text>
+    <text x="310" y="245" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">LIFO構造</text>
+    <text x="310" y="260" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">無限の記憶容量</text>
     
     <!-- Stack Operations -->
     <rect x="450" y="120" width="140" height="160" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="520" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">スタック操作</text>
-    <text x="460" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• push: データを積む</text>
-    <text x="470" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">トップに新要素追加</text>
-    <text x="460" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• pop: データを取り出す</text>
-    <text x="470" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">トップ要素を削除</text>
-    <text x="460" y="225" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• LIFO原則</text>
-    <text x="470" y="240" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">Last In, First Out</text>
-    <text x="460" y="255" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 記憶の階層構造</text>
+    <text x="520" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">スタック操作</text>
+    <text x="460" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• push: データを積む</text>
+    <text x="470" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">トップに新要素追加</text>
+    <text x="460" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• pop: データを取り出す</text>
+    <text x="470" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">トップ要素を削除</text>
+    <text x="460" y="225" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• LIFO原則</text>
+    <text x="470" y="240" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">Last In, First Out</text>
+    <text x="460" y="255" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 記憶の階層構造</text>
   </g>
   
   <!-- Section 2: Visual PDA Structure -->
   <g id="visual-pda">
     <rect x="620" y="80" width="540" height="220" fill="#fff3e0" stroke="#f57c00" stroke-width="2" rx="8"/>
-    <text x="890" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#f57c00">PDAの視覚的構造</text>
+    <text x="890" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#f57c00">PDAの視覚的構造</text>
     
     <!-- Input Tape -->
     <g id="input-tape">
-      <text x="650" y="135" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">入力テープ:</text>
+      <text x="650" y="135" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">入力テープ:</text>
       <rect x="740" y="120" width="25" height="20" fill="#e3f2fd" stroke="#1976d2" stroke-width="1"/>
-      <text x="752" y="133" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#1976d2">a</text>
+      <text x="752" y="133" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#1976d2">a</text>
       <rect x="765" y="120" width="25" height="20" fill="#e3f2fd" stroke="#1976d2" stroke-width="1"/>
-      <text x="777" y="133" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#1976d2">a</text>
+      <text x="777" y="133" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#1976d2">a</text>
       <rect x="790" y="120" width="25" height="20" fill="#ffcdd2" stroke="#d32f2f" stroke-width="2"/>
-      <text x="802" y="133" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#d32f2f">b</text>
+      <text x="802" y="133" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#d32f2f">b</text>
       <rect x="815" y="120" width="25" height="20" fill="#e3f2fd" stroke="#1976d2" stroke-width="1"/>
-      <text x="827" y="133" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#1976d2">b</text>
+      <text x="827" y="133" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#1976d2">b</text>
       
       <!-- Read head -->
       <polygon points="795,110 805,110 800,105" fill="#d32f2f"/>
-      <text x="800" y="102" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#d32f2f">読取ヘッド</text>
+      <text x="800" y="102" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#d32f2f">読取ヘッド</text>
     </g>
     
     <!-- Finite Control -->
     <g id="finite-control">
-      <text x="650" y="170" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">有限制御部:</text>
+      <text x="650" y="170" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">有限制御部:</text>
       <circle cx="760" cy="180" r="25" fill="#ffffff" stroke="#f57c00" stroke-width="3"/>
-      <text x="760" y="185" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">q₁</text>
-      <text x="760" y="215" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">現在状態</text>
+      <text x="760" y="185" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">q₁</text>
+      <text x="760" y="215" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">現在状態</text>
     </g>
     
     <!-- Stack -->
     <g id="stack">
-      <text x="880" y="135" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">スタック:</text>
+      <text x="880" y="135" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">スタック:</text>
       
       <!-- Stack cells -->
       <rect x="950" y="145" width="30" height="20" fill="#c8e6c9" stroke="#388e3c" stroke-width="2"/>
-      <text x="965" y="158" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" font-weight="bold" fill="#388e3c">A</text>
-      <text x="990" y="158" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#777">← トップ</text>
+      <text x="965" y="158" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" font-weight="bold" fill="#388e3c">A</text>
+      <text x="990" y="158" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#777">← トップ</text>
       
       <rect x="950" y="165" width="30" height="20" fill="#e8f5e8" stroke="#388e3c" stroke-width="1"/>
-      <text x="965" y="178" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#388e3c">A</text>
+      <text x="965" y="178" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#388e3c">A</text>
       
       <rect x="950" y="185" width="30" height="20" fill="#e8f5e8" stroke="#388e3c" stroke-width="1"/>
-      <text x="965" y="198" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#388e3c">Z₀</text>
+      <text x="965" y="198" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#388e3c">Z₀</text>
       
       <rect x="950" y="205" width="30" height="15" fill="#f5f5f5" stroke="#9e9e9e" stroke-width="1" stroke-dasharray="2,2"/>
-      <text x="965" y="214" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#9e9e9e">...</text>
+      <text x="965" y="214" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#9e9e9e">...</text>
       
       <!-- Stack operations arrows -->
       <path d="M 920 150 L 945 155" fill="none" stroke="#4caf50" stroke-width="2" marker-end="url(#arrowhead-green)"/>
-      <text x="885" y="148" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#4caf50">push</text>
+      <text x="885" y="148" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#4caf50">push</text>
       
       <path d="M 945 175 L 920 180" fill="none" stroke="#f44336" stroke-width="2" marker-end="url(#arrowhead-red)"/>
-      <text x="885" y="183" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#f44336">pop</text>
+      <text x="885" y="183" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#f44336">pop</text>
     </g>
     
     <!-- Transition function illustration -->
     <g id="transition-example">
-      <text x="650" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">遷移例: δ(q₁, b, A) = {(q₂, ε)}</text>
-      <text x="650" y="270" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">状態q₁で入力bを読み、スタックトップAをポップして状態q₂へ</text>
-      <text x="650" y="285" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">（εはスタックに何もプッシュしないことを意味）</text>
+      <text x="650" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">遷移例: δ(q₁, b, A) = {(q₂, ε)}</text>
+      <text x="650" y="270" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">状態q₁で入力bを読み、スタックトップAをポップして状態q₂へ</text>
+      <text x="650" y="285" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">（εはスタックに何もプッシュしないことを意味）</text>
     </g>
   </g>
   
   <!-- Section 3: Instantaneous Description and Transitions -->
   <g id="id-transitions">
     <rect x="40" y="320" width="1120" height="180" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="2" rx="8"/>
-    <text x="600" y="345" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#7b1fa2">瞬時記述と遷移</text>
+    <text x="600" y="345" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#7b1fa2">瞬時記述と遷移</text>
     
     <!-- ID Definition -->
     <rect x="60" y="360" width="200" height="120" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="160" y="380" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">瞬時記述(ID)</text>
-    <text x="160" y="405" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" fill="#333">(q, w, α) ∈ Q × Σ* × Γ*</text>
-    <text x="70" y="425" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• q: 現在状態</text>
-    <text x="70" y="440" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• w: 未読入力</text>
-    <text x="70" y="455" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• α: スタック内容</text>
-    <text x="70" y="470" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">左端がトップ</text>
+    <text x="160" y="380" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">瞬時記述(ID)</text>
+    <text x="160" y="405" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" fill="#333">(q, w, α) ∈ Q × Σ* × Γ*</text>
+    <text x="70" y="425" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• q: 現在状態</text>
+    <text x="70" y="440" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• w: 未読入力</text>
+    <text x="70" y="455" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• α: スタック内容</text>
+    <text x="70" y="470" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">左端がトップ</text>
     
     <!-- Transition Relation -->
     <rect x="280" y="360" width="240" height="120" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="400" y="380" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">遷移関係 ⊢</text>
-    <text x="400" y="405" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#333">(q, aw, Zα) ⊢ (p, w, βα)</text>
-    <text x="400" y="425" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">if (p, β) ∈ δ(q, a, Z)</text>
-    <text x="290" y="445" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">• Zをポップしてβをプッシュ</text>
-    <text x="290" y="460" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">• 入力aを消費</text>
-    <text x="290" y="470" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">• 状態qからpへ遷移</text>
+    <text x="400" y="380" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">遷移関係 ⊢</text>
+    <text x="400" y="405" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#333">(q, aw, Zα) ⊢ (p, w, βα)</text>
+    <text x="400" y="425" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">if (p, β) ∈ δ(q, a, Z)</text>
+    <text x="290" y="445" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">• Zをポップしてβをプッシュ</text>
+    <text x="290" y="460" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">• 入力aを消費</text>
+    <text x="290" y="470" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">• 状態qからpへ遷移</text>
     
     <!-- Nondeterminism -->
     <rect x="540" y="360" width="200" height="120" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="640" y="380" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">非決定性</text>
-    <text x="550" y="400" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 複数の選択肢可能</text>
-    <text x="550" y="415" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• ε-遷移可能</text>
-    <text x="560" y="430" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">入力を消費せずに遷移</text>
-    <text x="550" y="445" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 推測による計算</text>
-    <text x="550" y="460" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 並行計算パス</text>
+    <text x="640" y="380" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">非決定性</text>
+    <text x="550" y="400" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 複数の選択肢可能</text>
+    <text x="550" y="415" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• ε-遷移可能</text>
+    <text x="560" y="430" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">入力を消費せずに遷移</text>
+    <text x="550" y="445" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 推測による計算</text>
+    <text x="550" y="460" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 並行計算パス</text>
     
     <!-- Example Computation -->
     <rect x="760" y="360" width="380" height="120" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="950" y="380" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">計算例: {aⁿbⁿ | n ≥ 1}</text>
-    <text x="770" y="400" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">入力: aabb</text>
-    <text x="770" y="415" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">(q₀, aabb, Z₀) ⊢ (q₀, abb, AZ₀) ⊢ (q₀, bb, AAZ₀)</text>
-    <text x="770" y="430" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">⊢ (q₁, bb, AAZ₀) ⊢ (q₁, b, AZ₀) ⊢ (q₁, ε, Z₀)</text>
-    <text x="770" y="445" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• aを読んでAをプッシュ</text>
-    <text x="770" y="460" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• bを読んでAをポップ</text>
-    <text x="770" y="470" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">均等性をスタックで記憶</text>
+    <text x="950" y="380" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">計算例: {aⁿbⁿ | n ≥ 1}</text>
+    <text x="770" y="400" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">入力: aabb</text>
+    <text x="770" y="415" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">(q₀, aabb, Z₀) ⊢ (q₀, abb, AZ₀) ⊢ (q₀, bb, AAZ₀)</text>
+    <text x="770" y="430" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">⊢ (q₁, bb, AAZ₀) ⊢ (q₁, b, AZ₀) ⊢ (q₁, ε, Z₀)</text>
+    <text x="770" y="445" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• aを読んでAをプッシュ</text>
+    <text x="770" y="460" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• bを読んでAをポップ</text>
+    <text x="770" y="470" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">均等性をスタックで記憶</text>
   </g>
   
   <!-- Section 4: Acceptance Methods -->
   <g id="acceptance-methods">
     <rect x="40" y="520" width="1120" height="180" fill="#e8f5e8" stroke="#388e3c" stroke-width="2" rx="8"/>
-    <text x="600" y="545" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#388e3c">受理方式</text>
+    <text x="600" y="545" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#388e3c">受理方式</text>
     
     <!-- Final State Acceptance -->
     <rect x="60" y="560" width="350" height="120" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="235" y="580" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">最終状態による受理</text>
-    <text x="235" y="605" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#333">L(P) = {w | (q₀,w,Z₀) ⊢* (q,ε,α), q ∈ F}</text>
-    <text x="70" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 入力を全て読み終えた時に受理状態にいる</text>
-    <text x="70" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• スタックの内容は問わない</text>
-    <text x="70" y="655" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• F ≠ ∅ の場合に意味がある</text>
-    <text x="70" y="670" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 実装が直接的</text>
+    <text x="235" y="580" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">最終状態による受理</text>
+    <text x="235" y="605" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#333">L(P) = {w | (q₀,w,Z₀) ⊢* (q,ε,α), q ∈ F}</text>
+    <text x="70" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 入力を全て読み終えた時に受理状態にいる</text>
+    <text x="70" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• スタックの内容は問わない</text>
+    <text x="70" y="655" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• F ≠ ∅ の場合に意味がある</text>
+    <text x="70" y="670" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 実装が直接的</text>
     
     <!-- Empty Stack Acceptance -->
     <rect x="430" y="560" width="350" height="120" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="605" y="580" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">空スタックによる受理</text>
-    <text x="605" y="605" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#333">N(P) = {w | (q₀,w,Z₀) ⊢* (q,ε,ε)}</text>
-    <text x="440" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 入力を全て読み終えた時にスタックが空</text>
-    <text x="440" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 状態は問わない</text>
-    <text x="440" y="655" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• より自然な受理条件</text>
-    <text x="440" y="670" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• CFGとの対応が明確</text>
+    <text x="605" y="580" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">空スタックによる受理</text>
+    <text x="605" y="605" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#333">N(P) = {w | (q₀,w,Z₀) ⊢* (q,ε,ε)}</text>
+    <text x="440" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 入力を全て読み終えた時にスタックが空</text>
+    <text x="440" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 状態は問わない</text>
+    <text x="440" y="655" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• より自然な受理条件</text>
+    <text x="440" y="670" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• CFGとの対応が明確</text>
     
     <!-- Equivalence -->
     <rect x="800" y="560" width="340" height="120" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="970" y="580" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">受理方式の等価性</text>
-    <text x="970" y="605" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">最終状態受理 ≡ 空スタック受理</text>
-    <text x="810" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">相互変換アルゴリズムが存在</text>
-    <text x="810" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 最終状態→空スタック:</text>
-    <text x="820" y="655" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">受理状態からスタックを空にする遷移</text>
-    <text x="810" y="670" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 空スタック→最終状態:</text>
-    <text x="820" y="680" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#777">スタックが空になったら受理状態へ</text>
+    <text x="970" y="580" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">受理方式の等価性</text>
+    <text x="970" y="605" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">最終状態受理 ≡ 空スタック受理</text>
+    <text x="810" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">相互変換アルゴリズムが存在</text>
+    <text x="810" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 最終状態→空スタック:</text>
+    <text x="820" y="655" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">受理状態からスタックを空にする遷移</text>
+    <text x="810" y="670" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 空スタック→最終状態:</text>
+    <text x="820" y="680" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#777">スタックが空になったら受理状態へ</text>
   </g>
   
   <!-- Section 5: CFG-PDA Equivalence -->
   <g id="cfg-pda-equivalence">
     <rect x="40" y="720" width="1120" height="140" fill="#fff8e1" stroke="#f9a825" stroke-width="2" rx="8"/>
-    <text x="600" y="745" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#f9a825">CFGとPDAの等価性</text>
+    <text x="600" y="745" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#f9a825">CFGとPDAの等価性</text>
     
     <!-- Main Theorem -->
     <rect x="60" y="760" width="250" height="80" fill="#ffffff" stroke="#f9a825" stroke-width="1" rx="4"/>
-    <text x="185" y="780" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f9a825">基本定理</text>
-    <text x="185" y="805" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#333">文脈自由言語 ≡ PDAで受理される言語</text>
-    <text x="70" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">この等価性により文脈自由言語の</text>
-    <text x="70" y="835" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">計算モデルが明確になる</text>
+    <text x="185" y="780" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f9a825">基本定理</text>
+    <text x="185" y="805" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#333">文脈自由言語 ≡ PDAで受理される言語</text>
+    <text x="70" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">この等価性により文脈自由言語の</text>
+    <text x="70" y="835" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">計算モデルが明確になる</text>
     
     <!-- CFG to PDA -->
     <rect x="330" y="760" width="270" height="80" fill="#ffffff" stroke="#f9a825" stroke-width="1" rx="4"/>
-    <text x="465" y="780" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f9a825">CFG → PDA</text>
-    <text x="340" y="800" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">スタックで左導出をシミュレート:</text>
-    <text x="340" y="815" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">1. 初期記号をプッシュ</text>
-    <text x="340" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">2. 変数を生成規則で展開</text>
-    <text x="340" y="835" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">3. 終端記号をマッチング</text>
+    <text x="465" y="780" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f9a825">CFG → PDA</text>
+    <text x="340" y="800" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">スタックで左導出をシミュレート:</text>
+    <text x="340" y="815" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">1. 初期記号をプッシュ</text>
+    <text x="340" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">2. 変数を生成規則で展開</text>
+    <text x="340" y="835" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">3. 終端記号をマッチング</text>
     
     <!-- PDA to CFG -->
     <rect x="620" y="760" width="250" height="80" fill="#ffffff" stroke="#f9a825" stroke-width="1" rx="4"/>
-    <text x="745" y="780" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f9a825">PDA → CFG</text>
-    <text x="630" y="800" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">変数[q,A,p]で表現:</text>
-    <text x="630" y="815" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 状態qでスタックトップAから</text>
-    <text x="630" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 状態pでAを除去する過程</text>
-    <text x="630" y="835" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 系統的な変換手順</text>
+    <text x="745" y="780" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f9a825">PDA → CFG</text>
+    <text x="630" y="800" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">変数[q,A,p]で表現:</text>
+    <text x="630" y="815" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 状態qでスタックトップAから</text>
+    <text x="630" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 状態pでAを除去する過程</text>
+    <text x="630" y="835" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 系統的な変換手順</text>
     
     <!-- Practical Implications -->
     <rect x="890" y="760" width="250" height="80" fill="#ffffff" stroke="#f9a825" stroke-width="1" rx="4"/>
-    <text x="1015" y="780" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f9a825">実用的意義</text>
-    <text x="900" y="800" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 構文解析アルゴリズムの基礎</text>
-    <text x="900" y="815" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• コンパイラ設計の理論的裏付け</text>
-    <text x="900" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• プログラミング言語の処理</text>
-    <text x="900" y="835" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• XMLパーサなどへの応用</text>
+    <text x="1015" y="780" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f9a825">実用的意義</text>
+    <text x="900" y="800" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 構文解析アルゴリズムの基礎</text>
+    <text x="900" y="815" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• コンパイラ設計の理論的裏付け</text>
+    <text x="900" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• プログラミング言語の処理</text>
+    <text x="900" y="835" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• XMLパーサなどへの応用</text>
   </g>
   
   <!-- Arrow markers -->

--- a/docs/assets/images/diagrams/ch3_regex_to_nfa_thompson_steps.svg
+++ b/docs/assets/images/diagrams/ch3_regex_to_nfa_thompson_steps.svg
@@ -4,7 +4,7 @@
   <desc id="desc">リテラル、連結、和 (+)、クリーネ閉包 (*) の各構成規則を小さなNFAブロックで示し、最終的に複合正規表現を合成する手順の概観図。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .box { fill: #f8f9fa; stroke: #adb5bd; stroke-width: 1.5; }
       .state { fill: #fff; stroke: #495057; stroke-width: 1.5; }
       .accept { fill: #e6fcf5; }

--- a/docs/assets/images/diagrams/ch3_regular_languages_expressions.svg
+++ b/docs/assets/images/diagrams/ch3_regular_languages_expressions.svg
@@ -7,7 +7,7 @@
   <rect width="1200" height="900" fill="#f8f9fa"/>
   
   <!-- Title -->
-  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="24" font-weight="bold" fill="#1a1a1a">正規言語と正規表現</text>
+  <text x="600" y="30" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="24" font-weight="bold" fill="#1a1a1a">正規言語と正規表現</text>
   
   <!-- Main Container -->
   <rect x="20" y="50" width="1160" height="830" fill="none" stroke="#e1e5e9" stroke-width="2" rx="10"/>
@@ -15,216 +15,216 @@
   <!-- Section 1: Regular Expression Construction -->
   <g id="regex-construction">
     <rect x="40" y="80" width="560" height="200" fill="#e3f2fd" stroke="#1976d2" stroke-width="2" rx="8"/>
-    <text x="320" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#1976d2">正規表現の構成</text>
+    <text x="320" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#1976d2">正規表現の構成</text>
     
     <!-- Basic Elements -->
     <rect x="60" y="120" width="130" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="125" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">基本要素</text>
-    <text x="70" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• ∅: 空言語</text>
-    <text x="70" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• ε: 空文字列</text>
-    <text x="70" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• a: 単一記号</text>
-    <text x="70" y="210" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">対応する言語:</text>
-    <text x="70" y="225" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">∅, {ε}, {a}</text>
-    <text x="70" y="240" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">すべての正規表現</text>
-    <text x="70" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">の基礎</text>
+    <text x="125" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">基本要素</text>
+    <text x="70" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• ∅: 空言語</text>
+    <text x="70" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• ε: 空文字列</text>
+    <text x="70" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• a: 単一記号</text>
+    <text x="70" y="210" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">対応する言語:</text>
+    <text x="70" y="225" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">∅, {ε}, {a}</text>
+    <text x="70" y="240" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">すべての正規表現</text>
+    <text x="70" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">の基礎</text>
     
     <!-- Operations -->
     <rect x="200" y="120" width="140" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="270" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">演算</text>
-    <text x="210" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• R₁ + R₂: 和集合</text>
-    <text x="210" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• R₁R₂: 連結</text>
-    <text x="210" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• R*: クリーネ閉包</text>
-    <text x="210" y="210" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">意味:</text>
-    <text x="210" y="225" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">L(R₁) ∪ L(R₂)</text>
-    <text x="210" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">L(R₁)L(R₂)</text>
-    <text x="210" y="245" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">L(R)*</text>
+    <text x="270" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">演算</text>
+    <text x="210" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• R₁ + R₂: 和集合</text>
+    <text x="210" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• R₁R₂: 連結</text>
+    <text x="210" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• R*: クリーネ閉包</text>
+    <text x="210" y="210" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">意味:</text>
+    <text x="210" y="225" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">L(R₁) ∪ L(R₂)</text>
+    <text x="210" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">L(R₁)L(R₂)</text>
+    <text x="210" y="245" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">L(R)*</text>
     
     <!-- Priority -->
     <rect x="350" y="120" width="120" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="410" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">優先順位</text>
-    <text x="360" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#9c27b0">1. * (閉包)</text>
-    <text x="360" y="180" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">2. 連結</text>
-    <text x="360" y="200" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#4caf50">3. + (和)</text>
-    <text x="360" y="225" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">例: ab* + c</text>
-    <text x="360" y="240" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">= (a(b*)) + c</text>
+    <text x="410" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">優先順位</text>
+    <text x="360" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#9c27b0">1. * (閉包)</text>
+    <text x="360" y="180" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">2. 連結</text>
+    <text x="360" y="200" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#4caf50">3. + (和)</text>
+    <text x="360" y="225" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">例: ab* + c</text>
+    <text x="360" y="240" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">= (a(b*)) + c</text>
     
     <!-- Extensions -->
     <rect x="480" y="120" width="110" height="140" fill="#ffffff" stroke="#1976d2" stroke-width="1" rx="4"/>
-    <text x="535" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#1976d2">拡張記法</text>
-    <text x="490" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• R⁺: 正閉包</text>
-    <text x="500" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">(RR*)</text>
-    <text x="490" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• R?: オプション</text>
-    <text x="500" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">(R + ε)</text>
-    <text x="490" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• [abc]: 文字クラス</text>
-    <text x="500" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">(a + b + c)</text>
-    <text x="490" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">• [a-z]: 範囲指定</text>
+    <text x="535" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#1976d2">拡張記法</text>
+    <text x="490" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• R⁺: 正閉包</text>
+    <text x="500" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">(RR*)</text>
+    <text x="490" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• R?: オプション</text>
+    <text x="500" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">(R + ε)</text>
+    <text x="490" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• [abc]: 文字クラス</text>
+    <text x="500" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">(a + b + c)</text>
+    <text x="490" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">• [a-z]: 範囲指定</text>
   </g>
   
   <!-- Section 2: Examples -->
   <g id="examples">
     <rect x="620" y="80" width="540" height="200" fill="#fff3e0" stroke="#f57c00" stroke-width="2" rx="8"/>
-    <text x="890" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#f57c00">正規表現の例</text>
+    <text x="890" y="105" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#f57c00">正規表現の例</text>
     
     <!-- Basic Examples -->
     <rect x="640" y="120" width="250" height="140" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="765" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">基本例</text>
-    <text x="650" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">(0+1)*:</text>
-    <text x="660" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">すべての2進文字列</text>
-    <text x="650" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">0*10*:</text>
-    <text x="660" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">ちょうど1つの1</text>
-    <text x="650" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">(0+1)*11(0+1)*:</text>
-    <text x="660" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">11を含む文字列</text>
-    <text x="650" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">((0+1)(0+1))*:</text>
-    <text x="660" y="265" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">偶数長の2進文字列</text>
+    <text x="765" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">基本例</text>
+    <text x="650" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">(0+1)*:</text>
+    <text x="660" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">すべての2進文字列</text>
+    <text x="650" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">0*10*:</text>
+    <text x="660" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">ちょうど1つの1</text>
+    <text x="650" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">(0+1)*11(0+1)*:</text>
+    <text x="660" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">11を含む文字列</text>
+    <text x="650" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">((0+1)(0+1))*:</text>
+    <text x="660" y="265" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">偶数長の2進文字列</text>
     
     <!-- Practical Examples -->
     <rect x="900" y="120" width="250" height="140" fill="#ffffff" stroke="#f57c00" stroke-width="1" rx="4"/>
-    <text x="1025" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#f57c00">実用例</text>
-    <text x="910" y="160" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">[a-z]+:</text>
-    <text x="920" y="175" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">英小文字の列</text>
-    <text x="910" y="190" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">[0-9]+:</text>
-    <text x="920" y="205" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">数字の列</text>
-    <text x="910" y="220" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">a*b+c?:</text>
-    <text x="920" y="235" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">a後にb、任意でc</text>
-    <text x="910" y="250" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="11" fill="#555">[a-zA-Z][a-zA-Z0-9]*:</text>
-    <text x="920" y="265" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#777">識別子パターン</text>
+    <text x="1025" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#f57c00">実用例</text>
+    <text x="910" y="160" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">[a-z]+:</text>
+    <text x="920" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">英小文字の列</text>
+    <text x="910" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">[0-9]+:</text>
+    <text x="920" y="205" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">数字の列</text>
+    <text x="910" y="220" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">a*b+c?:</text>
+    <text x="920" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">a後にb、任意でc</text>
+    <text x="910" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="11" fill="#555">[a-zA-Z][a-zA-Z0-9]*:</text>
+    <text x="920" y="265" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#777">識別子パターン</text>
   </g>
   
   <!-- Section 3: Kleene's Theorem -->
   <g id="kleene-theorem">
     <rect x="40" y="300" width="560" height="180" fill="#e8f5e8" stroke="#388e3c" stroke-width="2" rx="8"/>
-    <text x="320" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#388e3c">Kleeneの定理</text>
+    <text x="320" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#388e3c">Kleeneの定理</text>
     
     <!-- Equivalence -->
     <rect x="60" y="340" width="180" height="120" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="150" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">等価性の定理</text>
-    <text x="150" y="385" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="14" font-weight="bold" fill="#333">正規表現 ≡ DFA ≡ NFA</text>
-    <text x="70" y="405" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">同じ言語クラスを表現</text>
-    <text x="70" y="420" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">相互変換可能</text>
-    <text x="70" y="435" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">計算能力が等価</text>
-    <text x="70" y="450" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">正規言語の特徴付け</text>
+    <text x="150" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">等価性の定理</text>
+    <text x="150" y="385" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="14" font-weight="bold" fill="#333">正規表現 ≡ DFA ≡ NFA</text>
+    <text x="70" y="405" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">同じ言語クラスを表現</text>
+    <text x="70" y="420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">相互変換可能</text>
+    <text x="70" y="435" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">計算能力が等価</text>
+    <text x="70" y="450" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">正規言語の特徴付け</text>
     
     <!-- Direction 1 -->
     <rect x="250" y="340" width="170" height="120" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="335" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">正規表現 → NFA</text>
-    <text x="260" y="380" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• Thompsonの構成法</text>
-    <text x="260" y="395" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 帰納的にオートマトン構築</text>
-    <text x="260" y="410" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• ε-遷移を使用</text>
-    <text x="260" y="425" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 構造的な対応</text>
-    <text x="260" y="440" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 効率的な実装</text>
+    <text x="335" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">正規表現 → NFA</text>
+    <text x="260" y="380" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• Thompsonの構成法</text>
+    <text x="260" y="395" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 帰納的にオートマトン構築</text>
+    <text x="260" y="410" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• ε-遷移を使用</text>
+    <text x="260" y="425" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 構造的な対応</text>
+    <text x="260" y="440" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 効率的な実装</text>
     
     <!-- Direction 2 -->
     <rect x="430" y="340" width="160" height="120" fill="#ffffff" stroke="#388e3c" stroke-width="1" rx="4"/>
-    <text x="510" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#388e3c">DFA → 正規表現</text>
-    <text x="440" y="380" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 状態消去法</text>
-    <text x="440" y="395" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• Ardenの補題</text>
-    <text x="440" y="410" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 連立方程式解法</text>
-    <text x="440" y="425" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 系統的な手順</text>
-    <text x="440" y="440" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 複雑な表現の可能性</text>
+    <text x="510" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#388e3c">DFA → 正規表現</text>
+    <text x="440" y="380" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 状態消去法</text>
+    <text x="440" y="395" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• Ardenの補題</text>
+    <text x="440" y="410" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 連立方程式解法</text>
+    <text x="440" y="425" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 系統的な手順</text>
+    <text x="440" y="440" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 複雑な表現の可能性</text>
   </g>
   
   <!-- Section 4: Properties -->
   <g id="properties">
     <rect x="620" y="300" width="540" height="180" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="2" rx="8"/>
-    <text x="890" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#7b1fa2">正規言語の性質</text>
+    <text x="890" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#7b1fa2">正規言語の性質</text>
     
     <!-- Closure -->
     <rect x="640" y="340" width="160" height="120" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="720" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">閉包性</text>
-    <text x="650" y="380" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 和集合 ∪</text>
-    <text x="650" y="395" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 積集合 ∩</text>
-    <text x="650" y="410" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 補集合 ¯</text>
-    <text x="650" y="425" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 連結 ・</text>
-    <text x="650" y="440" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• クリーネ閉包 *</text>
+    <text x="720" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">閉包性</text>
+    <text x="650" y="380" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 和集合 ∪</text>
+    <text x="650" y="395" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 積集合 ∩</text>
+    <text x="650" y="410" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 補集合 ¯</text>
+    <text x="650" y="425" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 連結 ・</text>
+    <text x="650" y="440" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• クリーネ閉包 *</text>
     
     <!-- Decidable -->
     <rect x="810" y="340" width="160" height="120" fill="#ffffff" stroke="#7b1fa2" stroke-width="1" rx="4"/>
-    <text x="890" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#7b1fa2">決定可能問題</text>
-    <text x="820" y="380" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 所属問題: w ∈ L?</text>
-    <text x="820" y="395" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 空問題: L = ∅?</text>
-    <text x="820" y="410" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 有限性: Lは有限?</text>
-    <text x="820" y="425" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 等価性: L₁ = L₂?</text>
-    <text x="820" y="440" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 包含関係: L₁ ⊆ L₂?</text>
+    <text x="890" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#7b1fa2">決定可能問題</text>
+    <text x="820" y="380" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 所属問題: w ∈ L?</text>
+    <text x="820" y="395" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 空問題: L = ∅?</text>
+    <text x="820" y="410" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 有限性: Lは有限?</text>
+    <text x="820" y="425" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 等価性: L₁ = L₂?</text>
+    <text x="820" y="440" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 包含関係: L₁ ⊆ L₂?</text>
     
     <!-- Pumping Lemma -->
     <rect x="980" y="340" width="170" height="120" fill="#ffffff" stroke="#ffebee" stroke-width="1" rx="4"/>
-    <text x="1065" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#d32f2f">正規言語の限界</text>
-    <text x="990" y="380" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">Pumping補題</text>
-    <text x="990" y="395" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 十分長い文字列にループ</text>
-    <text x="990" y="410" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 繰り返し可能な部分</text>
-    <text x="990" y="425" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 非正規性の証明法</text>
-    <text x="990" y="440" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 状態数による制約</text>
+    <text x="1065" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#d32f2f">正規言語の限界</text>
+    <text x="990" y="380" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">Pumping補題</text>
+    <text x="990" y="395" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 十分長い文字列にループ</text>
+    <text x="990" y="410" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 繰り返し可能な部分</text>
+    <text x="990" y="425" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 非正規性の証明法</text>
+    <text x="990" y="440" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 状態数による制約</text>
   </g>
   
   <!-- Section 5: Thompson Construction -->
   <g id="thompson-construction">
     <rect x="40" y="500" width="1120" height="180" fill="#e1f5fe" stroke="#0277bd" stroke-width="2" rx="8"/>
-    <text x="600" y="525" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#0277bd">Thompsonの構成法（正規表現→ε-NFA）</text>
+    <text x="600" y="525" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#0277bd">Thompsonの構成法（正規表現→ε-NFA）</text>
     
     <!-- Base Cases -->
     <rect x="60" y="540" width="200" height="120" fill="#ffffff" stroke="#0277bd" stroke-width="1" rx="4"/>
-    <text x="160" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#0277bd">基底ケース</text>
+    <text x="160" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#0277bd">基底ケース</text>
     
     <!-- Empty Language -->
     <g id="empty-lang">
-      <text x="70" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">∅ (空言語):</text>
+      <text x="70" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">∅ (空言語):</text>
       <circle cx="120" cy="595" r="8" fill="#ffffff" stroke="#0277bd" stroke-width="1"/>
       <circle cx="180" cy="595" r="8" fill="#ffffff" stroke="#0277bd" stroke-width="1"/>
       <circle cx="180" cy="595" r="5" fill="none" stroke="#0277bd" stroke-width="1"/>
-      <text x="120" y="599" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">q₀</text>
-      <text x="180" y="599" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">q₁</text>
-      <text x="150" y="608" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#777">遷移なし</text>
+      <text x="120" y="599" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">q₀</text>
+      <text x="180" y="599" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">q₁</text>
+      <text x="150" y="608" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#777">遷移なし</text>
     </g>
     
     <!-- Epsilon -->
     <g id="epsilon">
-      <text x="70" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">ε (空文字列):</text>
+      <text x="70" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">ε (空文字列):</text>
       <circle cx="120" cy="640" r="8" fill="#ffffff" stroke="#0277bd" stroke-width="1"/>
       <circle cx="180" cy="640" r="8" fill="#ffffff" stroke="#0277bd" stroke-width="1"/>
       <circle cx="180" cy="640" r="5" fill="none" stroke="#0277bd" stroke-width="1"/>
       <path d="M 128 640 L 172 640" fill="none" stroke="#0277bd" stroke-width="1" stroke-dasharray="2,1" marker-end="url(#arrowhead-blue)"/>
-      <text x="150" y="636" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">ε</text>
-      <text x="120" y="654" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">q₀</text>
-      <text x="180" y="654" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">q₁</text>
+      <text x="150" y="636" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">ε</text>
+      <text x="120" y="654" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">q₀</text>
+      <text x="180" y="654" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">q₁</text>
     </g>
     
     <!-- Symbol -->
     <g id="symbol">
-      <text x="190" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">a (単一記号):</text>
+      <text x="190" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">a (単一記号):</text>
       <circle cx="240" cy="640" r="8" fill="#ffffff" stroke="#0277bd" stroke-width="1"/>
       <circle cx="280" cy="640" r="8" fill="#ffffff" stroke="#0277bd" stroke-width="1"/>
       <circle cx="280" cy="640" r="5" fill="none" stroke="#0277bd" stroke-width="1"/>
       <path d="M 248 640 L 272 640" fill="none" stroke="#0277bd" stroke-width="1" marker-end="url(#arrowhead-blue)"/>
-      <text x="260" y="636" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">a</text>
-      <text x="240" y="654" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">q₀</text>
-      <text x="280" y="654" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">q₁</text>
+      <text x="260" y="636" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">a</text>
+      <text x="240" y="654" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">q₀</text>
+      <text x="280" y="654" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">q₁</text>
     </g>
     
     <!-- Union Construction -->
     <rect x="280" y="540" width="250" height="120" fill="#ffffff" stroke="#0277bd" stroke-width="1" rx="4"/>
-    <text x="405" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#0277bd">和集合 R₁ + R₂</text>
+    <text x="405" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#0277bd">和集合 R₁ + R₂</text>
     
     <!-- Union Diagram -->
     <g id="union-diagram">
-      <text x="295" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">新しい初期状態から</text>
-      <text x="295" y="592" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">両方の開始状態へε遷移</text>
+      <text x="295" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">新しい初期状態から</text>
+      <text x="295" y="592" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">両方の開始状態へε遷移</text>
       
       <!-- New start state -->
       <circle cx="320" cy="610" r="6" fill="#ffffff" stroke="#0277bd" stroke-width="1"/>
-      <text x="320" y="614" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="6" fill="#0277bd">q₀</text>
+      <text x="320" y="614" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="6" fill="#0277bd">q₀</text>
       
       <!-- R1 -->
       <rect x="350" y="600" width="25" height="12" fill="#e3f2fd" stroke="#0277bd" stroke-width="0.5" rx="2"/>
-      <text x="362" y="608" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">R₁</text>
+      <text x="362" y="608" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">R₁</text>
       
       <!-- R2 -->
       <rect x="350" y="615" width="25" height="12" fill="#e3f2fd" stroke="#0277bd" stroke-width="0.5" rx="2"/>
-      <text x="362" y="623" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">R₂</text>
+      <text x="362" y="623" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">R₂</text>
       
       <!-- New accept state -->
       <circle cx="400" cy="612" r="6" fill="#ffffff" stroke="#0277bd" stroke-width="1"/>
       <circle cx="400" cy="612" r="4" fill="none" stroke="#0277bd" stroke-width="0.5"/>
-      <text x="400" y="616" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="6" fill="#0277bd">qf</text>
+      <text x="400" y="616" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="6" fill="#0277bd">qf</text>
       
       <!-- Epsilon transitions -->
       <path d="M 326 608 L 348 606" fill="none" stroke="#0277bd" stroke-width="1" stroke-dasharray="1,1" marker-end="url(#arrowhead-blue-small)"/>
@@ -232,127 +232,127 @@
       <path d="M 377 606 L 394 610" fill="none" stroke="#0277bd" stroke-width="1" stroke-dasharray="1,1" marker-end="url(#arrowhead-blue-small)"/>
       <path d="M 377 618 L 394 614" fill="none" stroke="#0277bd" stroke-width="1" stroke-dasharray="1,1" marker-end="url(#arrowhead-blue-small)"/>
       
-      <text x="335" y="602" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="6" fill="#0277bd">ε</text>
-      <text x="335" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="6" fill="#0277bd">ε</text>
-      <text x="385" y="602" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="6" fill="#0277bd">ε</text>
-      <text x="385" y="625" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="6" fill="#0277bd">ε</text>
+      <text x="335" y="602" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="6" fill="#0277bd">ε</text>
+      <text x="335" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="6" fill="#0277bd">ε</text>
+      <text x="385" y="602" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="6" fill="#0277bd">ε</text>
+      <text x="385" y="625" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="6" fill="#0277bd">ε</text>
       
-      <text x="295" y="645" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">各受理状態から新しい</text>
-      <text x="295" y="655" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">受理状態へε遷移</text>
+      <text x="295" y="645" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">各受理状態から新しい</text>
+      <text x="295" y="655" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">受理状態へε遷移</text>
     </g>
     
     <!-- Concatenation Construction -->
     <rect x="550" y="540" width="250" height="120" fill="#ffffff" stroke="#0277bd" stroke-width="1" rx="4"/>
-    <text x="675" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#0277bd">連結 R₁R₂</text>
+    <text x="675" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#0277bd">連結 R₁R₂</text>
     
     <!-- Concatenation Diagram -->
     <g id="concat-diagram">
-      <text x="565" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">R₁の受理状態から</text>
-      <text x="565" y="592" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">R₂の開始状態へε遷移</text>
+      <text x="565" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">R₁の受理状態から</text>
+      <text x="565" y="592" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">R₂の開始状態へε遷移</text>
       
       <!-- R1 -->
       <rect x="590" y="605" width="30" height="15" fill="#e3f2fd" stroke="#0277bd" stroke-width="0.5" rx="2"/>
-      <text x="605" y="615" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#0277bd">R₁</text>
+      <text x="605" y="615" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#0277bd">R₁</text>
       
       <!-- R2 -->
       <rect x="650" y="605" width="30" height="15" fill="#e3f2fd" stroke="#0277bd" stroke-width="0.5" rx="2"/>
-      <text x="665" y="615" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#0277bd">R₂</text>
+      <text x="665" y="615" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#0277bd">R₂</text>
       
       <!-- Connection -->
       <path d="M 620 612 L 650 612" fill="none" stroke="#0277bd" stroke-width="1" stroke-dasharray="2,1" marker-end="url(#arrowhead-blue-small)"/>
-      <text x="635" y="608" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">ε</text>
+      <text x="635" y="608" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">ε</text>
       
-      <text x="565" y="640" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">R₁の受理状態を非受理に</text>
-      <text x="565" y="652" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">R₂の受理状態のみが受理</text>
+      <text x="565" y="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">R₁の受理状態を非受理に</text>
+      <text x="565" y="652" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">R₂の受理状態のみが受理</text>
     </g>
     
     <!-- Kleene Star Construction -->
     <rect x="820" y="540" width="320" height="120" fill="#ffffff" stroke="#0277bd" stroke-width="1" rx="4"/>
-    <text x="980" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#0277bd">クリーネ閉包 R*</text>
+    <text x="980" y="560" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#0277bd">クリーネ閉包 R*</text>
     
     <!-- Kleene Diagram -->
     <g id="kleene-diagram">
-      <text x="835" y="580" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">新しい初期状態（受理状態でもある）</text>
+      <text x="835" y="580" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">新しい初期状態（受理状態でもある）</text>
       
       <!-- New start/accept state -->
       <circle cx="870" cy="600" r="8" fill="#ffffff" stroke="#0277bd" stroke-width="1"/>
       <circle cx="870" cy="600" r="5" fill="none" stroke="#0277bd" stroke-width="1"/>
-      <text x="870" y="604" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="6" fill="#0277bd">q₀</text>
+      <text x="870" y="604" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="6" fill="#0277bd">q₀</text>
       
       <!-- R automaton -->
       <rect x="920" y="592" width="30" height="16" fill="#e3f2fd" stroke="#0277bd" stroke-width="0.5" rx="2"/>
-      <text x="935" y="602" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="8" fill="#0277bd">R</text>
+      <text x="935" y="602" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="8" fill="#0277bd">R</text>
       
       <!-- New final state -->
       <circle cx="980" cy="600" r="8" fill="#ffffff" stroke="#0277bd" stroke-width="1"/>
       <circle cx="980" cy="600" r="5" fill="none" stroke="#0277bd" stroke-width="1"/>
-      <text x="980" y="604" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="6" fill="#0277bd">qf</text>
+      <text x="980" y="604" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="6" fill="#0277bd">qf</text>
       
       <!-- Forward epsilon -->
       <path d="M 878 600 L 920 600" fill="none" stroke="#0277bd" stroke-width="1" stroke-dasharray="2,1" marker-end="url(#arrowhead-blue-small)"/>
-      <text x="900" y="596" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">ε</text>
+      <text x="900" y="596" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">ε</text>
       
       <!-- Output epsilon -->
       <path d="M 950 600 L 972 600" fill="none" stroke="#0277bd" stroke-width="1" stroke-dasharray="2,1" marker-end="url(#arrowhead-blue-small)"/>
-      <text x="960" y="596" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">ε</text>
+      <text x="960" y="596" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">ε</text>
       
       <!-- Loop back -->
       <path d="M 972 592 Q 935 575 878 592" fill="none" stroke="#0277bd" stroke-width="1" stroke-dasharray="2,1" marker-end="url(#arrowhead-blue-small)"/>
-      <text x="925" y="580" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">ε</text>
+      <text x="925" y="580" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">ε</text>
       
       <!-- Direct path for empty string -->
       <path d="M 878 608 Q 925 625 972 608" fill="none" stroke="#0277bd" stroke-width="1" stroke-dasharray="2,1" marker-end="url(#arrowhead-blue-small)"/>
-      <text x="925" y="635" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="7" fill="#0277bd">ε</text>
+      <text x="925" y="635" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="7" fill="#0277bd">ε</text>
       
-      <text x="835" y="650" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">4つのε遷移: 開始→R, R終了→終了,</text>
-      <text x="835" y="662" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="9" fill="#555">R終了→R開始, 開始→終了(ε受理用)</text>
+      <text x="835" y="650" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">4つのε遷移: 開始→R, R終了→終了,</text>
+      <text x="835" y="662" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="9" fill="#555">R終了→R開始, 開始→終了(ε受理用)</text>
     </g>
   </g>
   
   <!-- Section 6: Regular Language Applications -->
   <g id="applications">
     <rect x="40" y="700" width="1120" height="160" fill="#fce4ec" stroke="#c2185b" stroke-width="2" rx="8"/>
-    <text x="600" y="725" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="18" font-weight="bold" fill="#c2185b">正規言語の実用的応用</text>
+    <text x="600" y="725" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="18" font-weight="bold" fill="#c2185b">正規言語の実用的応用</text>
     
     <!-- Lexical Analysis -->
     <rect x="60" y="740" width="220" height="105" fill="#ffffff" stroke="#c2185b" stroke-width="1" rx="4"/>
-    <text x="170" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#c2185b">字句解析</text>
-    <text x="70" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• プログラミング言語のトークン化</text>
-    <text x="70" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• キーワード、識別子、数値の認識</text>
-    <text x="70" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• コメント、文字列リテラル処理</text>
-    <text x="70" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• flex, lexのような字句解析器</text>
+    <text x="170" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#c2185b">字句解析</text>
+    <text x="70" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• プログラミング言語のトークン化</text>
+    <text x="70" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• キーワード、識別子、数値の認識</text>
+    <text x="70" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• コメント、文字列リテラル処理</text>
+    <text x="70" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• flex, lexのような字句解析器</text>
     
     <!-- Text Processing -->
     <rect x="300" y="740" width="220" height="105" fill="#ffffff" stroke="#c2185b" stroke-width="1" rx="4"/>
-    <text x="410" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#c2185b">テキスト処理</text>
-    <text x="310" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 正規表現エンジン（grep, sed）</text>
-    <text x="310" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• パターンマッチングと置換</text>
-    <text x="310" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• データ抽出と前処理</text>
-    <text x="310" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• ログファイル解析</text>
+    <text x="410" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#c2185b">テキスト処理</text>
+    <text x="310" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 正規表現エンジン（grep, sed）</text>
+    <text x="310" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• パターンマッチングと置換</text>
+    <text x="310" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• データ抽出と前処理</text>
+    <text x="310" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• ログファイル解析</text>
     
     <!-- Protocol Verification -->
     <rect x="540" y="740" width="220" height="105" fill="#ffffff" stroke="#c2185b" stroke-width="1" rx="4"/>
-    <text x="650" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#c2185b">プロトコル検証</text>
-    <text x="550" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 通信プロトコルの状態遷移</text>
-    <text x="550" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• ネットワークセキュリティ</text>
-    <text x="550" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• ファイアウォールルール</text>
-    <text x="550" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• パケットフィルタリング</text>
+    <text x="650" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#c2185b">プロトコル検証</text>
+    <text x="550" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 通信プロトコルの状態遷移</text>
+    <text x="550" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• ネットワークセキュリティ</text>
+    <text x="550" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• ファイアウォールルール</text>
+    <text x="550" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• パケットフィルタリング</text>
     
     <!-- Bioinformatics -->
     <rect x="780" y="740" width="220" height="105" fill="#ffffff" stroke="#c2185b" stroke-width="1" rx="4"/>
-    <text x="890" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#c2185b">バイオインフォマティクス</text>
-    <text x="790" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• DNA配列パターン検索</text>
-    <text x="790" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 遺伝子配列の特徴抽出</text>
-    <text x="790" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• タンパク質構造解析</text>
-    <text x="790" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• 配列アライメント</text>
+    <text x="890" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#c2185b">バイオインフォマティクス</text>
+    <text x="790" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• DNA配列パターン検索</text>
+    <text x="790" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 遺伝子配列の特徴抽出</text>
+    <text x="790" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• タンパク質構造解析</text>
+    <text x="790" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• 配列アライメント</text>
     
     <!-- XML/HTML Processing -->
     <rect x="1020" y="740" width="120" height="105" fill="#ffffff" stroke="#c2185b" stroke-width="1" rx="4"/>
-    <text x="1080" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="12" font-weight="bold" fill="#c2185b">構造化データ</text>
-    <text x="1030" y="780" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• XML/HTML解析</text>
-    <text x="1030" y="795" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• JSON検証</text>
-    <text x="1030" y="810" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• CSVパーシング</text>
-    <text x="1030" y="825" font-family="-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif" font-size="10" fill="#555">• データ変換</text>
+    <text x="1080" y="760" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="12" font-weight="bold" fill="#c2185b">構造化データ</text>
+    <text x="1030" y="780" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• XML/HTML解析</text>
+    <text x="1030" y="795" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• JSON検証</text>
+    <text x="1030" y="810" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• CSVパーシング</text>
+    <text x="1030" y="825" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'" font-size="10" fill="#555">• データ変換</text>
   </g>
   
   <!-- Arrow markers -->

--- a/docs/assets/images/diagrams/ch4_halting_problem_diagonalization.svg
+++ b/docs/assets/images/diagrams/ch4_halting_problem_diagonalization.svg
@@ -6,7 +6,7 @@
   
   <defs>
     <style>
-      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
+      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
       .small-text { font-size: 12px; }
       .large-text { font-size: 16px; font-weight: bold; }
       .input-box { fill: #f8f9fa; stroke: #6c757d; stroke-width: 2; rx: 8; }

--- a/docs/assets/images/diagrams/ch4_language_class_hierarchy.svg
+++ b/docs/assets/images/diagrams/ch4_language_class_hierarchy.svg
@@ -6,7 +6,7 @@
   
   <defs>
     <style>
-      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
+      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
       .small-text { font-size: 12px; }
       .large-text { font-size: 16px; font-weight: bold; }
       .all-languages { fill: #ffebee; stroke: #d32f2f; stroke-width: 3; rx: 12; }

--- a/docs/assets/images/diagrams/ch4_many_one_reduction.svg
+++ b/docs/assets/images/diagrams/ch4_many_one_reduction.svg
@@ -6,7 +6,7 @@
   
   <defs>
     <style>
-      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
+      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
       .small-text { font-size: 12px; }
       .large-text { font-size: 16px; font-weight: bold; }
       .language-box { fill: #fff3e0; stroke: #f57c00; stroke-width: 2; rx: 8; }

--- a/docs/assets/images/diagrams/ch4_partial_recursive_functions.svg
+++ b/docs/assets/images/diagrams/ch4_partial_recursive_functions.svg
@@ -6,7 +6,7 @@
   
   <defs>
     <style>
-      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
+      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
       .small-text { font-size: 12px; }
       .large-text { font-size: 16px; font-weight: bold; }
       .basic-function { fill: #e3f2fd; stroke: #1976d2; stroke-width: 2; rx: 8; }
@@ -42,17 +42,17 @@
   <!-- Zero function -->
   <rect x="70" y="110" width="120" height="60" class="basic-function"/>
   <text x="130" y="130" class="diagram-text small-text">零関数</text>
-  <text x="130" y="150" class="diagram-text small-text" style="font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;">Z(x) = 0</text>
+  <text x="130" y="150" class="diagram-text small-text" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">Z(x) = 0</text>
   
   <!-- Successor function -->
   <rect x="220" y="110" width="120" height="60" class="basic-function"/>
   <text x="280" y="130" class="diagram-text small-text">後続関数</text>
-  <text x="280" y="150" class="diagram-text small-text" style="font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;">S(x) = x + 1</text>
+  <text x="280" y="150" class="diagram-text small-text" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">S(x) = x + 1</text>
   
   <!-- Projection function -->
   <rect x="370" y="110" width="160" height="60" class="basic-function"/>
   <text x="450" y="130" class="diagram-text small-text">射影関数</text>
-  <text x="450" y="150" class="diagram-text small-text" style="font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;">P_i^n(x₁,...,xₙ) = xᵢ</text>
+  <text x="450" y="150" class="diagram-text small-text" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">P_i^n(x₁,...,xₙ) = xᵢ</text>
   
   <!-- Construction Methods Group -->
   <rect x="50" y="220" width="700" height="200" class="group-border"/>
@@ -61,19 +61,19 @@
   <!-- Composition -->
   <rect x="70" y="260" width="140" height="80" class="composition"/>
   <text x="140" y="280" class="diagram-text small-text">合成</text>
-  <text x="140" y="300" class="diagram-text small-text" style="font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;">h = f ∘ (g₁,...,gₖ)</text>
+  <text x="140" y="300" class="diagram-text small-text" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">h = f ∘ (g₁,...,gₖ)</text>
   <text x="140" y="320" class="diagram-text small-text">h(x̄) = f(g₁(x̄),...,gₖ(x̄))</text>
   
   <!-- Primitive Recursion -->
   <rect x="240" y="260" width="160" height="80" class="primitive-recursion"/>
   <text x="320" y="280" class="diagram-text small-text">原始再帰</text>
-  <text x="320" y="300" class="diagram-text small-text" style="font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;">h(0,x̄) = f(x̄)</text>
-  <text x="320" y="320" class="diagram-text small-text" style="font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;">h(n+1,x̄) = g(n,h(n,x̄),x̄)</text>
+  <text x="320" y="300" class="diagram-text small-text" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">h(0,x̄) = f(x̄)</text>
+  <text x="320" y="320" class="diagram-text small-text" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">h(n+1,x̄) = g(n,h(n,x̄),x̄)</text>
   
   <!-- Minimization -->
   <rect x="430" y="260" width="140" height="80" class="minimization"/>
   <text x="500" y="280" class="diagram-text small-text">最小化</text>
-  <text x="500" y="300" class="diagram-text small-text" style="font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;">h(x̄) = μy[f(x̄,y) = 0]</text>
+  <text x="500" y="300" class="diagram-text small-text" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">h(x̄) = μy[f(x̄,y) = 0]</text>
   <text x="500" y="320" class="diagram-text small-text">最小のyを求める</text>
   
   <!-- Construction flow arrows -->

--- a/docs/assets/images/diagrams/ch4_rice_theorem_reduction.svg
+++ b/docs/assets/images/diagrams/ch4_rice_theorem_reduction.svg
@@ -6,7 +6,7 @@
 
   <defs>
     <style>
-      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
+      .diagram-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; fill: #2c3e50; text-anchor: middle; }
       .small-text { font-size: 12px; }
       .large-text { font-size: 16px; font-weight: bold; }
       .input-box { fill: #fff3e0; stroke: #f57c00; stroke-width: 2; rx: 8; }

--- a/docs/assets/images/diagrams/ch5_big_o_growth_curves.svg
+++ b/docs/assets/images/diagrams/ch5_big_o_growth_curves.svg
@@ -7,8 +7,8 @@
     <style>
       .axis { stroke: #222; stroke-width: 1.5; }
       .grid { stroke: #ddd; stroke-width: 1; }
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
-      .legend { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
+      .legend { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .c1 { stroke: #2b8a3e; stroke-width: 2.5; fill: none; }
       .c2 { stroke: #1c7ed6; stroke-width: 2.5; fill: none; }
       .c3 { stroke: #f08c00; stroke-width: 2.5; fill: none; }

--- a/docs/assets/images/diagrams/ch5_complexity_class_inclusions.svg
+++ b/docs/assets/images/diagrams/ch5_complexity_class_inclusions.svg
@@ -32,7 +32,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -40,7 +40,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -48,7 +48,7 @@
       }
       
       .class-name { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -56,7 +56,7 @@
       }
       
       .class-notation { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -65,7 +65,7 @@
       .small { font-size: 8px; }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -73,7 +73,7 @@
       }
       
       .relation-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 8px; 
         font-weight: 400; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch5_complexity_classes_hierarchy.svg
+++ b/docs/assets/images/diagrams/ch5_complexity_classes_hierarchy.svg
@@ -13,11 +13,11 @@
       .complexity-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -25,7 +25,7 @@
       }
       
       .class-name { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 16px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .class-desc { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: middle; 
@@ -58,7 +58,7 @@
       }
       
       .properties-text {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px;
         font-weight: 400;
         text-anchor: start;

--- a/docs/assets/images/diagrams/ch5_complexity_time_hierarchy.svg
+++ b/docs/assets/images/diagrams/ch5_complexity_time_hierarchy.svg
@@ -25,7 +25,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -33,7 +33,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -41,7 +41,7 @@
       }
       
       .class-name { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -49,7 +49,7 @@
       }
       
       .class-notation { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -57,7 +57,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -65,7 +65,7 @@
       }
       
       .inclusion-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch5_cook_levin_grid.svg
+++ b/docs/assets/images/diagrams/ch5_cook_levin_grid.svg
@@ -5,10 +5,10 @@
     <style>
       .grid { stroke: #adb5bd; stroke-width: 1; fill: none; }
       .tcell { fill: #f8f9fa; stroke: #dee2e6; }
-      .label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; fill: #333; }
-      .title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 600; fill: #1a1a1a; text-anchor: middle; }
-      .section { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #2c3e50; }
-      .note { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 11px; fill: #555; }
+      .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; fill: #333; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 600; fill: #1a1a1a; text-anchor: middle; }
+      .section { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #2c3e50; }
+      .note { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; fill: #555; }
       .cnf { fill: #fff3e0; stroke: #ff9800; stroke-width: 2; rx: 8; }
       .ok { fill: #e8f5e9; stroke: #4caf50; stroke-width: 2; rx: 6; }
       .bad { fill: #ffebee; stroke: #d32f2f; stroke-width: 2; rx: 6; }

--- a/docs/assets/images/diagrams/ch5_np_completeness_reduction_chain.svg
+++ b/docs/assets/images/diagrams/ch5_np_completeness_reduction_chain.svg
@@ -26,7 +26,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -42,7 +42,7 @@
       }
       
       .concept-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -50,7 +50,7 @@
       }
       
       .problem-name { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -58,7 +58,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -66,7 +66,7 @@
       }
       
       .mathematical-def { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: start; 
@@ -74,7 +74,7 @@
       }
       
       .reduction-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 8px; 
         font-weight: 400; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch5_np_completeness_reductions.svg
+++ b/docs/assets/images/diagrams/ch5_np_completeness_reductions.svg
@@ -9,11 +9,11 @@
       .problem-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -21,7 +21,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -29,7 +29,7 @@
       }
       
       .problem-name { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -38,7 +38,7 @@
       }
       
       .problem-desc { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: middle; 
@@ -54,7 +54,7 @@
       }
       
       .concept-text {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px;
         font-weight: 400;
         text-anchor: start;
@@ -62,7 +62,7 @@
       }
       
       .formula {
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px;
         font-weight: 500;
         text-anchor: start;

--- a/docs/assets/images/diagrams/ch5_p_vs_np_structure.svg
+++ b/docs/assets/images/diagrams/ch5_p_vs_np_structure.svg
@@ -27,7 +27,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -35,7 +35,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -43,7 +43,7 @@
       }
       
       .class-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 13px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -51,7 +51,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -59,7 +59,7 @@
       }
       
       .example { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -68,7 +68,7 @@
       }
       
       .mathematical-statement { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 
@@ -76,7 +76,7 @@
       }
       
       .implication-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch5_reduction_sat_to_vertex_cover_gadget.svg
+++ b/docs/assets/images/diagrams/ch5_reduction_sat_to_vertex_cover_gadget.svg
@@ -4,7 +4,7 @@
   <desc id="desc">変数ガジェット（x_i と ¬x_i を結ぶ辺）と節ガジェット（節頂点から各リテラル頂点への辺）を示す最小例。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .node { fill: #fff; stroke: #495057; stroke-width: 1.8; }
       .edge { stroke: #868e96; stroke-width: 1.6; }
       .var { fill: #e7f5ff; stroke: #228be6; }

--- a/docs/assets/images/diagrams/ch6_algorithm_paradigms.svg
+++ b/docs/assets/images/diagrams/ch6_algorithm_paradigms.svg
@@ -26,7 +26,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .paradigm-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 16px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -42,7 +42,7 @@
       }
       
       .step-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -50,7 +50,7 @@
       }
       
       .step-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: middle; 
@@ -58,7 +58,7 @@
       }
       
       .example-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -66,7 +66,7 @@
       }
       
       .example-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -74,7 +74,7 @@
       }
       
       .repeat-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch6_complexity_classes.svg
+++ b/docs/assets/images/diagrams/ch6_complexity_classes.svg
@@ -28,7 +28,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -36,7 +36,7 @@
       }
       
       .class-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -45,7 +45,7 @@
       }
       
       .class-name { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 12px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -53,7 +53,7 @@
       }
       
       .example-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -61,7 +61,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch6_dynamic_programming_conditions.svg
+++ b/docs/assets/images/diagrams/ch6_dynamic_programming_conditions.svg
@@ -26,7 +26,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .box-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -42,7 +42,7 @@
       }
       
       .condition-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: middle; 
@@ -50,7 +50,7 @@
       }
       
       .example-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -58,7 +58,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch6_master_theorem.svg
+++ b/docs/assets/images/diagrams/ch6_master_theorem.svg
@@ -26,7 +26,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .box-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -42,7 +42,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 12px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -50,7 +50,7 @@
       }
 
       .condition { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: middle; 
@@ -58,7 +58,7 @@
       }
       
       .example-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -66,7 +66,7 @@
       }
       
       .explanation { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch7_avl_tree_rotations.svg
+++ b/docs/assets/images/diagrams/ch7_avl_tree_rotations.svg
@@ -12,7 +12,7 @@
       .rotation-arrow { stroke: #ff9800; stroke-width: 4px; fill: none; marker-end: url(#rotation-arrowhead); }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -20,7 +20,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -28,7 +28,7 @@
       }
       
       .node-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -37,7 +37,7 @@
       }
       
       .height-label { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -45,7 +45,7 @@
       }
       
       .subtree-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -54,7 +54,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -62,7 +62,7 @@
       }
       
       .operation-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 16px; 
         font-weight: 600; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch7_basic_data_structures.svg
+++ b/docs/assets/images/diagrams/ch7_basic_data_structures.svg
@@ -26,7 +26,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -34,7 +34,7 @@
       }
       
       .structure-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -42,7 +42,7 @@
       }
       
       .memory-label { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -51,7 +51,7 @@
       }
       
       .index-label { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: middle; 
@@ -59,7 +59,7 @@
       }
       
       .property-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -67,7 +67,7 @@
       }
       
       .complexity-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 9px; 
         font-weight: 500; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch7_skip_list_structure.svg
+++ b/docs/assets/images/diagrams/ch7_skip_list_structure.svg
@@ -15,7 +15,7 @@
       .search-path { stroke: #4caf50; stroke-width: 3px; fill: none; marker-end: url(#search-arrowhead); }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -23,7 +23,7 @@
       }
       
       .level-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -31,7 +31,7 @@
       }
       
       .node-label { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -40,7 +40,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -48,7 +48,7 @@
       }
       
       .search-step { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -56,7 +56,7 @@
       }
       
       .complexity-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch7_union_find_optimization.svg
+++ b/docs/assets/images/diagrams/ch7_union_find_optimization.svg
@@ -15,7 +15,7 @@
       .compression-arrow { stroke: #4caf50; stroke-width: 3px; fill: none; marker-end: url(#compression-arrowhead); }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -23,7 +23,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -31,7 +31,7 @@
       }
       
       .node-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -40,7 +40,7 @@
       }
       
       .rank-label { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 9px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -48,7 +48,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -56,7 +56,7 @@
       }
       
       .problem-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -64,7 +64,7 @@
       }
       
       .benefit-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -72,7 +72,7 @@
       }
       
       .complexity-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch8_bfs_vs_dfs_compare.svg
+++ b/docs/assets/images/diagrams/ch8_bfs_vs_dfs_compare.svg
@@ -4,7 +4,7 @@
   <desc id="desc">同一グラフに対して、BFS と DFS の到達順と生成される探索木の違いを2パネルで比較した図。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .node { fill: #fff; stroke: #495057; stroke-width: 1.8; }
       .edge { stroke: #adb5bd; stroke-width: 1.4; }
       .tree { stroke: #228be6; stroke-width: 2.2; }

--- a/docs/assets/images/diagrams/ch8_bipartite_graph_matching.svg
+++ b/docs/assets/images/diagrams/ch8_bipartite_graph_matching.svg
@@ -4,11 +4,11 @@
   
   <defs>
     <style>
-      .title-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 600; fill: #2d3748; }
-      .section-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #4a5568; }
-      .node-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 600; fill: #2d3748; }
-      .result-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 11px; font-weight: 400; fill: #2d3748; }
-      .note-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; font-weight: 400; fill: #4a5568; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 600; fill: #2d3748; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #4a5568; }
+      .node-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 600; fill: #2d3748; }
+      .result-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; font-weight: 400; fill: #2d3748; }
+      .note-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: #4a5568; }
       .left-node { fill: #fed7d7; stroke: #e53e3e; stroke-width: 2; }
       .right-node { fill: #bee3f8; stroke: #3182ce; stroke-width: 2; }
       .matched-left { fill: #c6f6d5; stroke: #38a169; stroke-width: 2.5; }

--- a/docs/assets/images/diagrams/ch8_dfs_bfs_comparison.svg
+++ b/docs/assets/images/diagrams/ch8_dfs_bfs_comparison.svg
@@ -12,7 +12,7 @@
       .bfs-edge { stroke: #4caf50; stroke-width: 3px; fill: none; }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -20,7 +20,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -28,7 +28,7 @@
       }
       
       .vertex-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -37,7 +37,7 @@
       }
       
       .time-label { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -45,7 +45,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -53,7 +53,7 @@
       }
       
       .order-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 12px; 
         font-weight: 500; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch8_dijkstra_algorithm_execution.svg
+++ b/docs/assets/images/diagrams/ch8_dijkstra_algorithm_execution.svg
@@ -4,12 +4,12 @@
   
   <defs>
     <style>
-      .title-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 600; fill: #2d3748; }
-      .section-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #4a5568; }
-      .node-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 500; fill: #2d3748; }
-      .distance-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; font-weight: 400; fill: #2d3748; }
-      .edge-weight { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; font-weight: 500; fill: #4a5568; }
-      .result-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 11px; font-weight: 400; fill: #2d3748; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 600; fill: #2d3748; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #4a5568; }
+      .node-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: #2d3748; }
+      .distance-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: #2d3748; }
+      .edge-weight { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 500; fill: #4a5568; }
+      .result-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; font-weight: 400; fill: #2d3748; }
       .arrow { fill: #718096; }
       .initial-node { fill: #fed7d7; stroke: #e53e3e; stroke-width: 2; }
       .processed-node { fill: #c6f6d5; stroke: #38a169; stroke-width: 2; }

--- a/docs/assets/images/diagrams/ch8_dijkstra_step_trace.svg
+++ b/docs/assets/images/diagrams/ch8_dijkstra_step_trace.svg
@@ -4,7 +4,7 @@
   <desc id="desc">始点sから他頂点への最短距離を段階的に確定する様子。確定集合Sとフロンティアの更新を模式的に示す。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .node { fill: #fff; stroke: #495057; stroke-width: 2; }
       .fixed { fill: #e6fcf5; }
       .frontier { fill: #fff3bf; }

--- a/docs/assets/images/diagrams/ch8_maximum_flow_minimum_cut.svg
+++ b/docs/assets/images/diagrams/ch8_maximum_flow_minimum_cut.svg
@@ -4,12 +4,12 @@
   
   <defs>
     <style>
-      .title-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 600; fill: #2d3748; }
-      .section-title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #4a5568; }
-      .node-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 600; fill: #2d3748; }
-      .flow-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; font-weight: 500; fill: #2d3748; }
-      .result-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 11px; font-weight: 400; fill: #2d3748; }
-      .note-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 10px; font-weight: 400; fill: #4a5568; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 600; fill: #2d3748; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #4a5568; }
+      .node-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 600; fill: #2d3748; }
+      .flow-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 500; fill: #2d3748; }
+      .result-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; font-weight: 400; fill: #2d3748; }
+      .note-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: #4a5568; }
       .source-node { fill: #fed7d7; stroke: #e53e3e; stroke-width: 2.5; }
       .sink-node { fill: #bee3f8; stroke: #3182ce; stroke-width: 2.5; }
       .intermediate-node { fill: #f7fafc; stroke: #718096; stroke-width: 2; }

--- a/docs/assets/images/diagrams/ch8_mst_kruskal_unionfind.svg
+++ b/docs/assets/images/diagrams/ch8_mst_kruskal_unionfind.svg
@@ -4,7 +4,7 @@
   <desc id="desc">昇順の辺を順に見て、閉路を作らなければ採用し、Union-Findで集合を合併する流れの模式図。</desc>
   <defs>
     <style>
-      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; }
+      .label { fill: #111; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; }
       .panel { fill: #f8f9fa; stroke: #dee2e6; }
       .node { fill: #fff; stroke: #495057; stroke-width: 1.6; }
       .edge { stroke: #868e96; stroke-width: 1.6; }

--- a/docs/assets/images/diagrams/ch9_dpll_cdcl_side_by_side.svg
+++ b/docs/assets/images/diagrams/ch9_dpll_cdcl_side_by_side.svg
@@ -7,10 +7,10 @@
       .box { fill: #e3f2fd; stroke: #1976d2; stroke-width: 2; rx: 6; }
       .box2 { fill: #e8f5e9; stroke: #388e3c; stroke-width: 2; rx: 6; }
       .warn { fill: #fff3e0; stroke: #ff9800; stroke-width: 2; rx: 6; }
-      .title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 18px; font-weight: 600; text-anchor: middle; fill: #1a1a1a; }
-      .heading { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 14px; font-weight: 600; fill: #2c3e50; }
-      .text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 11px; fill: #333; }
-      .label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; font-size: 12px; font-weight: 600; fill: #333; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 18px; font-weight: 600; text-anchor: middle; fill: #1a1a1a; }
+      .heading { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: 600; fill: #2c3e50; }
+      .text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; fill: #333; }
+      .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 600; fill: #333; }
       .arrow { stroke: #6c757d; stroke-width: 2; fill: none; marker-end: url(#a); }
     </style>
     <marker id="a" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">

--- a/docs/assets/images/diagrams/ch9_hoare_logic_inference_rules.svg
+++ b/docs/assets/images/diagrams/ch9_hoare_logic_inference_rules.svg
@@ -12,11 +12,11 @@
       .rule-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -24,7 +24,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -32,7 +32,7 @@
       }
       
       .rule-name { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 13px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -40,7 +40,7 @@
       }
       
       .formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -49,7 +49,7 @@
       }
       
       .example-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: middle; 
@@ -57,7 +57,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch9_hoare_logic_inference_system.svg
+++ b/docs/assets/images/diagrams/ch9_hoare_logic_inference_system.svg
@@ -17,7 +17,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -25,7 +25,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -33,7 +33,7 @@
       }
       
       .rule-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -41,7 +41,7 @@
       }
       
       .rule-formula { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 
@@ -49,7 +49,7 @@
       }
       
       .rule-formula-center { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -57,7 +57,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -65,7 +65,7 @@
       }
       
       .example-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch9_propositional_logic_decision_procedures.svg
+++ b/docs/assets/images/diagrams/ch9_propositional_logic_decision_procedures.svg
@@ -11,11 +11,11 @@
       .procedure-box { 
         rx: 4px; 
         ry: 4px; 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -23,7 +23,7 @@
       }
       
       .subtitle { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -31,7 +31,7 @@
       }
       
       .step-label { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 500; 
         text-anchor: middle; 
@@ -40,7 +40,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -48,7 +48,7 @@
       }
       
       .complexity-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: middle; 

--- a/docs/assets/images/diagrams/ch9_temporal_logic_model_checking.svg
+++ b/docs/assets/images/diagrams/ch9_temporal_logic_model_checking.svg
@@ -25,7 +25,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -33,7 +33,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -41,7 +41,7 @@
       }
       
       .logic-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -49,7 +49,7 @@
       }
       
       .operator-text { 
-        font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         font-size: 11px; 
         font-weight: 500; 
         text-anchor: start; 
@@ -57,7 +57,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -65,7 +65,7 @@
       }
       
       .example-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/ch9_theorem_proving_systems.svg
+++ b/docs/assets/images/diagrams/ch9_theorem_proving_systems.svg
@@ -25,7 +25,7 @@
       }
       
       .title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 18px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -33,7 +33,7 @@
       }
       
       .section-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 14px; 
         font-weight: 600; 
         text-anchor: middle; 
@@ -41,7 +41,7 @@
       }
       
       .system-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 12px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -49,7 +49,7 @@
       }
       
       .feature-title { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 11px; 
         font-weight: 600; 
         text-anchor: start; 
@@ -57,7 +57,7 @@
       }
       
       .description { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 10px; 
         font-weight: 400; 
         text-anchor: start; 
@@ -65,7 +65,7 @@
       }
       
       .bullet-text { 
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         font-size: 9px; 
         font-weight: 400; 
         text-anchor: start; 

--- a/docs/assets/images/diagrams/computational-complexity.svg
+++ b/docs/assets/images/diagrams/computational-complexity.svg
@@ -4,11 +4,11 @@
   <desc id="desc">P、NP、NP完全、PSPACE、EXPTIME などの複雑性クラスの包含関係と問題例を示す概観図。</desc>
   <defs>
     <style>
-      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
-      .class-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #fff; }
-      .section-title { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; font-weight: bold; fill: #2c3e50; }
-      .text-content { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #2c3e50; }
-      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .class-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: bold; fill: #fff; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: bold; fill: #2c3e50; }
+      .text-content { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; fill: #2c3e50; }
+      .small-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; fill: #7f8c8d; }
       .math-text { font-family: 'Times New Roman', serif; font-size: 12px; fill: #2c3e50; font-style: italic; }
       .p-class { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; opacity: 0.7; }
       .np-class { fill: #3498db; stroke: #2980b9; stroke-width: 2; opacity: 0.7; }

--- a/docs/assets/images/diagrams/turing-machine.svg
+++ b/docs/assets/images/diagrams/turing-machine.svg
@@ -4,11 +4,11 @@
   <desc id="desc">無限テープ、読み書きヘッド、制御装置、状態遷移など、チューリングマシンの基本構成要素を示す図。受理・拒否・現在状態の例示を含む。</desc>
   <defs>
     <style>
-      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
-      .component-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #fff; }
-      .state-text { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; fill: #2c3e50; font-weight: bold; }
-      .symbol-text { font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace; font-size: 14px; fill: #2c3e50; font-weight: bold; }
-      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .component-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: bold; fill: #fff; }
+      .state-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; fill: #2c3e50; font-weight: bold; }
+      .symbol-text { font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-size: 14px; fill: #2c3e50; font-weight: bold; }
+      .small-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; fill: #7f8c8d; }
       .tape-cell { fill: #fff; stroke: #34495e; stroke-width: 2; }
       .head-box { fill: #e74c3c; stroke: #c0392b; stroke-width: 2; }
       .control-box { fill: #3498db; stroke: #2980b9; stroke-width: 2; }


### PR DESCRIPTION
## 変更内容
SVG 図表内の `font-family` 指定を、書籍共通のフォントスタック（`--font-sans` / `--font-mono` 相当）に統一しました。

- 対象: `docs/**/*.svg`
- 実行: `book-formatter/scripts/svg-font-normalize.js docs --apply`

## 補足
- 一部SVGに含まれていた **不正な属性クォート**（`font-family="... "Segoe UI" ..."` のような未エスケープ）も併せて補修し、SVGがパース可能な状態になることを確認しています。
- このPRは SVG 内の `font-family` のみを機械的に正規化しています（図形/レイアウトには触れていません）。
