### PR TITLE
afterword を navigation.yml に追加して前後リンクを有効化

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -55,3 +55,7 @@ appendices:
   path: /appendices/f/
 - title: "付録G: AI/ML と理論計算機科学の接続"
   path: /appendices/g/
+
+afterword:
+- title: あとがき
+  path: /afterword/


### PR DESCRIPTION
## 背景
GitHub Pages の `/afterword/` で「前へ/次へ」リンクが無効（disabled）になっており、本文からの連続閲覧が途切れる状態でした。

原因は `docs/_data/navigation.yml` に afterword が含まれておらず、ページナビゲーションの順序解決がフォールバック経路になった結果、前後関係が決定できなかったためです。

## 対応
- `docs/_data/navigation.yml` に `afterword` を追加し、ナビゲーションの順序に含めました。

## 期待される効果
- `/afterword/` で `rel="prev"` が生成され、「前へ」で直前ページへ戻れるようになります。
