### PR TITLE
docs: proofread and clarify chapter 12

### DIFF
--- a/docs/chapter-12/index.md
+++ b/docs/chapter-12/index.md
@@ -111,8 +111,8 @@ P2: r2 = x; x = r2 + 1
 Client: send(Server, ("square", 5))
         receive(Server) = 25
 
-Server: msg = receive(Client)
-        send(Client, msg[1] * msg[1])
+Server: ("square", n) = receive(Client)
+        send(Client, n * n)
 ```
 同期通信なら送受信は同時に成立し、非同期通信なら送信済みメッセージがキューに蓄積されて後で受信されます。
 


### PR DESCRIPTION
## 概要（必須）

- 変更内容:
  - `docs/` を公開正本として、第12章の校正・表記整合・最小例補強を実施しました。

## 影響範囲（必須）

- 対象章/ページ（例: /chapters/chapter01/）: `/chapter-12/`
- 影響（例: 追記 / 構成変更 / リンク修正 / 図表修正）: 追記 / 表記修正 / 図版配置整理

## 変更ファイル

- `docs/chapter-12/index.md`

## 主要改善点

- 共有メモリ、メッセージパッシング、双模倣等価、Petri ネット、CTL、合意問題、線形化可能性に初学者向けの最小例を追加
- 抽象的な節を「定義/背景/最小例/注意点」に沿って補強し、主述と説明順を整理
- `happens-before` 図を共有メモリ節へ、ABA 問題図とロックフリー実務メモを並行データ構造節へ移動し、参照整合を改善
- ベーカリーアルゴリズム節のコードブロック混在を解消し、メタ情報の節名表記も実内容に合わせて調整

## 断定更新しなかった箇所

- 12.4.4 の TLA+ / TLC 実行手順は環境依存のため、jar 入手方法やツール提供形態の断定更新は行っていません
- 12.5.3 の Byzantine 条件・FLP 定理は既存の理論記述を維持し、変動しうる実装事情や製品動向の追記は行っていません

## QA（必須）

- [ ] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）: 部分PASS
  - 実行URL: ローカル実行
  - PASS: `check-unicode.js` / `check-textlint.js` / `check-links.js` / `check-layout-risk.js` / `check-markdown-structure.js` を `docs/` 対象で実行
  - 未実施: Jekyll build / built-site smoke（ローカル環境に `ruby` / `bundle` が無く実行不可）

## 手動確認必要箇所

- GitHub Pages 相当の表示で、第12章の図版移動後も本文導線が自然か
- モバイル幅でコードブロックと最小例の改行が崩れないか
- `Peterson.tla` / `Peterson.cfg` へのリンク表示が期待どおりか

## 実行した検証

- `node .../check-unicode.js docs --allowlist .book-formatter/unicode-allowlist.json --fail-on warn`
- `node .../check-textlint.js docs --fail-on error`
- `node .../check-links.js docs`
- `node .../check-layout-risk.js docs --fail-on error`
- `node .../check-markdown-structure.js docs --fail-on error`
- 参考: `markdownlint docs/chapter-12/index.md` は既存章全体のスタイル差分を多数報告するため、採否判定には未使用

## Pages確認（原則必須）

- 確認URL: https://itdojp.github.io/theoretical-computer-science-textbook/
- [ ] トップページ HTTP 200
- [ ] 主要導線（navigation.yml 相当）で 404 が無い
- [ ] 表示崩れが無い（図表/表/コード中心）

## 補足

- 既知の制約 / TODO:
  - `ruby` / `bundle` が無い環境のため、Pages ビルドと smoke は CI または手動確認をお願いします
