### PR TITLE
[codex] Check navigation coverage for docs pages

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -47,6 +47,9 @@ jobs:
             echo "dir=." >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check navigation covers published pages
+        run: python3 scripts/check_navigation_coverage.py
+
       - name: Unicode check (fail on warnings)
         run: node book-formatter/scripts/check-unicode.js "${{ steps.scan.outputs.dir }}" --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Check search-data.json is up-to-date
         run: python3 scripts/generate_search_data.py --check
 
+      - name: Check navigation covers published pages
+        run: python3 scripts/check_navigation_coverage.py
+
       - name: Docs regression lint (Markdown patterns)
         run: python3 scripts/docs_regression_lint.py
 

--- a/.github/workflows/nav-link-check.yml
+++ b/.github/workflows/nav-link-check.yml
@@ -52,8 +52,17 @@ jobs:
               paths = []
               for key in ['introduction','chapters','additional','resources','appendices','afterword']:
                   for item in (data.get(key) or []):
-                      p = item.get('path') or ''
-                      if p: paths.append(p)
+                      if isinstance(item, dict):
+                          nested = item.get('items')
+                          if not isinstance(nested, list):
+                              nested = item.get('children')
+                          if isinstance(nested, list):
+                              for sub in nested:
+                                  if isinstance(sub, dict) and sub.get('path'):
+                                      paths.append(sub.get('path'))
+                              continue
+                          p = item.get('path') or ''
+                          if p: paths.append(p)
               return paths
           def discover():
               paths=[]

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ python3 scripts/generate_search_data.py --check
 python3 scripts/generate_index.py --check
 
 # 本文・ビルド検証
+npm run check:navigation
 python3 scripts/docs_regression_lint.py
 python3 scripts/notation_lint.py
 bundle exec jekyll build --source docs --config docs/_config.yml --destination _site
@@ -139,6 +140,8 @@ python3 scripts/html_notation_check.py --site-root _site
 make test
 npm run spellcheck
 ```
+
+`npm run check:navigation` は `docs/_data/navigation.yml` の入れ子項目を含む全パスと、公開対象の `docs/**/*.md` ページが相互に対応していることを検証します。
 
 ## 技術構成
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preview": "npm run build && npx http-server _site -p 8080 --silent",
     "deploy": "gh-pages -d _site",
     "clean": "rm -rf _site .jekyll-cache",
-    "test": "npm run lint && npm run check-links",
+    "test": "npm run check:navigation && npm run lint && npm run check-links",
     "lint": "markdownlint 'src/**/*.md' --ignore node_modules",
     "lint:light": "markdownlint 'src/**/*.md' --ignore node_modules",
     "spellcheck": "cspell --config cspell.json --no-progress 'src/**/*.md' 'docs/**/*.md' 'README.md' 'CONTRIBUTING.md' 'CHANGELOG.md'",
@@ -23,10 +23,10 @@
     "svg:lint:a11y": "bash scripts/svg-lint-a11y.sh",
     "svg:inventory": "bash scripts/diagrams-inventory.sh",
     "check-links": "markdown-link-check src/**/*.md",
-    "help": "echo 'Available commands:\n  npm start - Start development server\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'"
+    "help": "echo 'Available commands:\n  npm start - Start development server\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'",
+    "check:navigation": "python3 scripts/check_navigation_coverage.py"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "@cspell/dict-filetypes": "^3.0.15",
     "@cspell/dict-node": "^5.0.9",
@@ -42,7 +42,9 @@
     "book",
     "documentation",
     "japanese",
-    "computer-science","theory","algorithm"
+    "computer-science",
+    "theory",
+    "algorithm"
   ],
   "repository": {
     "type": "git",
@@ -51,5 +53,5 @@
   "bugs": {
     "url": "https://github.com/itdojp/theoretical-computer-science-textbook/issues"
   },
-  "homepage": "https://github.com/itdojp/theoretical-computer-science-textbook#readme"
+  "homepage": "https://itdojp.github.io/theoretical-computer-science-textbook/"
 }

--- a/scripts/check_navigation_coverage.py
+++ b/scripts/check_navigation_coverage.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Validate that docs navigation covers the published Markdown pages.
+
+The scheduled nav-link workflow historically read only top-level `path` fields.
+This checker uses the same source of truth (`docs/_data/navigation.yml`) but
+flattens nested items as well, then verifies that every configured path has a
+corresponding docs page and every docs page is represented by navigation (except
+for the top page `/`). It intentionally uses only the Python standard library so
+it can run in CI without extra dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+NAV_PATH_RE = re.compile(r"^\s*path:\s*(?P<value>.+?)\s*$")
+FRONT_MATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n", re.DOTALL)
+SCALAR_RE = re.compile(r"^(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*?)\s*$")
+
+EXCLUDED_PAGE_PARTS = {"assets"}
+
+
+class CheckError(ValueError):
+    pass
+
+
+def unquote_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+        return value[1:-1]
+    return value
+
+
+def normalize_public_path(value: str, *, source: str) -> str:
+    path = unquote_scalar(value)
+    if not path:
+        raise CheckError(f"{source}: path must not be empty")
+    if path.startswith(("http://", "https://", "mailto:")):
+        raise CheckError(f"{source}: external paths are not expected in navigation: {path!r}")
+    if "{{" in path or "}}" in path:
+        raise CheckError(f"{source}: Liquid expressions are not allowed in canonical paths")
+    if "#" in path or "?" in path:
+        raise CheckError(f"{source}: path must not include query or fragment: {path!r}")
+    if "\\" in path:
+        raise CheckError(f"{source}: path must use forward slashes: {path!r}")
+    if not path.startswith("/"):
+        path = "/" + path
+    decoded = unquote(path)
+    if any(part in (".", "..") for part in decoded.split("/") if part):
+        raise CheckError(f"{source}: path traversal is not allowed: {path!r}")
+    if "%2f" in path.lower() or "%5c" in path.lower():
+        raise CheckError(f"{source}: encoded path separators are not allowed: {path!r}")
+    lower = path.lower()
+    if path != "/" and not lower.endswith((".html", ".htm", ".pdf", ".txt", "/")):
+        path += "/"
+    return path
+
+
+def parse_front_matter(path: Path) -> dict[str, str]:
+    match = FRONT_MATTER_RE.match(path.read_text(encoding="utf-8"))
+    if not match:
+        return {}
+    data: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        if line[:1].isspace():
+            continue
+        scalar = SCALAR_RE.match(line)
+        if scalar:
+            data[scalar.group("key")] = unquote_scalar(scalar.group("value"))
+    return data
+
+
+def navigation_paths(nav_path: Path) -> list[str]:
+    paths: list[str] = []
+    for lineno, line in enumerate(nav_path.read_text(encoding="utf-8").splitlines(), start=1):
+        match = NAV_PATH_RE.match(line)
+        if not match:
+            continue
+        paths.append(normalize_public_path(match.group("value"), source=f"{nav_path}:{lineno}"))
+    return paths
+
+
+def default_public_path(md_path: Path) -> str:
+    rel = md_path.relative_to("docs")
+    if md_path.name == "index.md":
+        parent = rel.parent.as_posix()
+        return "/" if parent == "." else f"/{parent}/"
+    return f"/{rel.with_suffix('').as_posix()}/"
+
+
+def docs_pages() -> dict[str, Path]:
+    pages: dict[str, Path] = {}
+    for md_path in sorted(Path("docs").rglob("*.md")):
+        rel_parts = md_path.relative_to("docs").parts
+        if any(part.startswith("_") for part in rel_parts):
+            continue
+        if any(part in EXCLUDED_PAGE_PARTS for part in rel_parts):
+            continue
+        fm = parse_front_matter(md_path)
+        public_path = fm.get("permalink") or default_public_path(md_path)
+        public_path = normalize_public_path(public_path, source=f"{md_path}:permalink")
+        if public_path in pages:
+            raise CheckError(f"duplicate public path: {public_path} ({pages[public_path]} and {md_path})")
+        pages[public_path] = md_path
+    return pages
+
+
+def duplicates(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    dupes: list[str] = []
+    for value in values:
+        if value in seen and value not in dupes:
+            dupes.append(value)
+        seen.add(value)
+    return dupes
+
+
+def main() -> int:
+    try:
+        nav = navigation_paths(Path("docs/_data/navigation.yml"))
+        pages = docs_pages()
+    except CheckError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    for duplicate in duplicates(nav):
+        errors.append(f"duplicate navigation path: {duplicate}")
+
+    page_paths = set(pages)
+    nav_paths = set(nav)
+    for path in sorted(nav_paths - page_paths):
+        errors.append(f"navigation path has no docs page: {path}")
+
+    listed_paths = nav_paths | {"/"}
+    for path in sorted(page_paths - listed_paths):
+        errors.append(f"docs page is not listed in navigation: {pages[path]} -> {path}")
+
+    if errors:
+        print("navigation coverage check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"OK: navigation covers {len(nav_paths)} paths and {len(page_paths)} docs pages")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_navigation_coverage.py
+++ b/scripts/check_navigation_coverage.py
@@ -145,7 +145,11 @@ def main() -> int:
             print(f"- {error}", file=sys.stderr)
         return 1
 
-    print(f"OK: navigation covers {len(nav_paths)} paths and {len(page_paths)} docs pages")
+    root_pages = sum(1 for p in page_paths if p == "/")
+    print(
+        f"OK: {len(nav_paths)} navigation paths cover {len(page_paths) - root_pages} docs pages"
+        f" (root '/' is implicit; {len(page_paths)} total)"
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary
- Add `scripts/check_navigation_coverage.py` to flatten `docs/_data/navigation.yml` including nested chapter items and verify it covers every published Markdown page under `docs/`.
- Wire the navigation coverage gate into CI, Book QA, and `npm test` via `npm run check:navigation`.
- Update the scheduled nav-link workflow so it includes nested `items` entries instead of only top-level `path` fields.
- Document the local navigation check and align `package.json.homepage` to the public GitHub Pages URL.

## Why
`docs/_data/navigation.yml` groups chapters under nested `items`, but the scheduled nav-link workflow only read top-level `path` values. That left most chapter routes outside the scheduled public URL probe. This PR adds a dedicated, stdlib-only coverage gate and fixes the scheduled workflow flattening logic.

## Validation
- `python3 -m py_compile scripts/check_navigation_coverage.py`
- `python3 scripts/check_navigation_coverage.py`
- `npm test` completed with exit code 0; existing `markdown-link-check` diagnostics for the `src/` mirror were observed in output and are pre-existing, while the new `check:navigation` step passed.
- `npm audit --omit=dev --omit=optional`
- `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/tcs-bundle bundle exec jekyll build --source docs --config docs/_config.yml --destination /home/devuser/work/CodeX/booksB/.codex-local/tmp/tcs-site-after`
- `python3 scripts/html_notation_check.py --site-root /home/devuser/work/CodeX/booksB/.codex-local/tmp/tcs-site-after`
- book-formatter pinned at `itdojp/book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4`: unicode, textlint, docs links, layout risk, markdown structure
- Negative fixtures: missing navigation target and duplicate navigation target failed as expected; CRLF front matter fixture passed
- `git diff --check`