### PR TITLE
chore: active workflowsをNode.js 24対応Actionへ更新

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -92,7 +92,7 @@ jobs:
           path: ${{ runner.temp }}/layout-risk-report.json
           if-no-files-found: ignore
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build (Jekyll; GitHub Pages compatible)
         uses: actions/jekyll-build-pages@v1

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Create GitHub Release and upload assets
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 120


### PR DESCRIPTION
## Summary
- Book QAの`actions/configure-pages`を`v5`から`v6`へ更新
- stale workflowの`actions/stale`を`v9`から`v10`へ更新
- release workflowの`softprops/action-gh-release`を`v1`から`v3`へ更新
- workflow入力、permissions、Jekyll/release契約は維持

## Verification
- actionlint 1.7.12（変更3 workflow）: PASS
- `npm ci`: PASS
- `npm audit`: 0 vulnerabilities
- `npm test`: PASS
- `npm run build`: PASS
- `git diff --check`: PASS
- 対象旧参照: 0 / 新参照: 3

## Contract verification
- `stale.yml`はschedule/手動実行、`release-artifacts.yml`はtag `v*`で動作するため、PRでは副作用を伴う本番イベントを生成しない
- 現行入力が更新先majorでも維持されることをAction metadataで確認し、YAML/actionlintと通常CIで構文・既存契約を検証する

## Separated debt
- Jekyll/Faraday warningは#403、npmの`whatwg-encoding@3.1.1`非推奨warningは#405で追跡

Closes #404
