### PR TITLE
Resolve Faraday retry dependency warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "https://rubygems.org"
 # GitHub Pages公式gem
 gem "github-pages", "~> 232", group: :jekyll_plugins
 
+# jekyll-github-metadata -> OctokitのFaraday 2 retry middleware
+gem "faraday-retry", "~> 2.4"
+
 # Windows対応
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 


### PR DESCRIPTION
## 概要

Jekyll build時にOctokitが出すFaraday 2 retry middleware warningを、正規の分離gemを明示することで解消します。

Closes #403

## 根拠

- `jekyll-github-metadata 2.16.1` は `octokit 4.25.1` を利用します。
- OctokitはFaraday 2以上で `require 'faraday/retry'` を行い、未導入なら対象warningを出します。
- 同じOctokit既定middleware stackは、利用可能な場合に `Faraday::Retry::Middleware` を組み込みます。
- `faraday-retry 2.4.0` のruntime条件は `faraday ~> 2.0`、Ruby `>= 2.6` で、現行CI（Ruby 3.2 / Faraday 2.14.2）と互換です。

## 変更

- `Gemfile` に `faraday-retry ~> 2.4` を追加
- 本リポジトリの既存方針どおり`Gemfile.lock`は追跡せず、GitHub Pages向け`github-pages ~> 232`と追加依存の互換範囲をGemfileで管理

## 検証

- `bundle install`: 成功（`faraday-retry 2.4.0`）
- `bundle check`: 成功
- Octokit load後に `Faraday::Retry::Middleware` が定義されることを確認
- `bundle exec jekyll build --source docs --config docs/_config.yml --destination _site`: 成功、対象warning 0件
- `npm ci`: 成功（whatwg-encoding warningは別Issue #405）
- `npm test`: 成功、npm audit 0件
- `git diff --check`: 成功

## Scope

本文変更、npm依存更新、warning抑止は含みません。
