### PR TITLE
fix: v1.2.0オフラインReleaseを安全に再実行可能にする

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -2,6 +2,12 @@ name: Release Artifacts
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing canonical tag to publish (blank builds artifacts only)"
+        required: false
+        default: ""
+        type: string
   push:
     tags:
       - "v*"
@@ -10,15 +16,62 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.release_target.outputs.release_tag }}
+      artifact_label: ${{ steps.artifact_label.outputs.value }}
 
     steps:
-      - name: Checkout repository
+      - name: Checkout release tooling
         uses: actions/checkout@v6
+        with:
+          ref: main
+          path: release-tooling
+          persist-credentials: false
+
+      - name: Resolve release target
+        id: release_target
+        shell: bash
+        env:
+          REQUESTED_RELEASE_TAG: ${{ inputs.release_tag || '' }}
+        run: |
+          set -euo pipefail
+          release_tag=""
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]] && [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "manual release runs must use the main branch workflow" >&2
+            exit 1
+          fi
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            release_tag="${GITHUB_REF_NAME}"
+            target_ref="${GITHUB_REF_NAME}"
+          elif [[ -n "${REQUESTED_RELEASE_TAG}" ]]; then
+            release_tag="${REQUESTED_RELEASE_TAG}"
+            target_ref="${REQUESTED_RELEASE_TAG}"
+          else
+            target_ref="${GITHUB_SHA}"
+          fi
+
+          if [[ -n "${release_tag}" ]] && [[ ! "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release_tag must match v<major>.<minor>.<patch>" >&2
+            exit 1
+          fi
+
+          artifact_source="${release_tag:-${GITHUB_REF_NAME}}"
+          echo "target_ref=${target_ref}" >> "${GITHUB_OUTPUT}"
+          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+          echo "artifact_source=${artifact_source}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout release source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.release_target.outputs.target_ref }}
+          path: release-source
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -27,20 +80,30 @@ jobs:
 
       - name: Verify canonical publication metadata and release tag
         shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release_target.outputs.release_tag }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            python3 scripts/check_publication_metadata.py --release-tag "${GITHUB_REF_NAME}"
+          if [[ -n "${RELEASE_TAG}" ]]; then
+            source_head="$(git -C release-source rev-parse HEAD)"
+            tag_head="$(git -C release-source rev-list -n 1 "${RELEASE_TAG}")"
+            test "${source_head}" = "${tag_head}"
+            python3 release-tooling/scripts/check_publication_metadata.py \
+              --root release-source --contract-root release-tooling \
+              --release-tag "${RELEASE_TAG}"
           else
-            python3 scripts/check_publication_metadata.py
+            python3 release-tooling/scripts/check_publication_metadata.py \
+              --root release-source --contract-root release-tooling
           fi
 
       - name: Resolve filesystem-safe artifact label
         id: artifact_label
         shell: bash
+        env:
+          ARTIFACT_SOURCE: ${{ steps.release_target.outputs.artifact_source }}
         run: |
           set -euo pipefail
-          artifact_label="${GITHUB_REF_NAME//\//-}"
+          artifact_label="${ARTIFACT_SOURCE//\//-}"
           test -n "${artifact_label}"
           echo "value=${artifact_label}" >> "${GITHUB_OUTPUT}"
 
@@ -61,16 +124,22 @@ jobs:
 
       - name: Build offline sources (Markdown)
         run: |
-          python3 scripts/build_offline_book.py --target epub --out dist/book.epub.md
-          python3 scripts/build_offline_book.py --target pdf --out dist/book.pdf.md --asset-out dist
+          python3 release-tooling/scripts/build_offline_book.py \
+            --docs-root release-source/docs \
+            --config release-source/docs/book-config.json \
+            --target epub --out dist/book.epub.md
+          python3 release-tooling/scripts/build_offline_book.py \
+            --docs-root release-source/docs \
+            --config release-source/docs/book-config.json \
+            --target pdf --out dist/book.pdf.md --asset-out dist
 
       - name: Build EPUB
         run: |
           artifact_label="${{ steps.artifact_label.outputs.value }}"
           pandoc dist/book.epub.md \
             --toc \
-            --css docs/assets/css/epub.css \
-            --resource-path=docs \
+            --css release-source/docs/assets/css/epub.css \
+            --resource-path=release-source/docs \
             -o "dist/theoretical-computer-science-textbook-${artifact_label}.epub"
 
       - name: Build PDF
@@ -92,11 +161,25 @@ jobs:
             dist/theoretical-computer-science-textbook-*.epub
           if-no-files-found: error
 
+  publish:
+    needs: build
+    if: needs.build.outputs.release_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download verified workflow artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: offline-artifacts
+          path: dist
+
       - name: Create GitHub Release and upload assets
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ needs.build.outputs.release_tag }}
           generate_release_notes: true
           files: |
-            dist/theoretical-computer-science-textbook-${{ steps.artifact_label.outputs.value }}.pdf
-            dist/theoretical-computer-science-textbook-${{ steps.artifact_label.outputs.value }}.epub
+            dist/theoretical-computer-science-textbook-${{ needs.build.outputs.artifact_label }}.pdf
+            dist/theoretical-computer-science-textbook-${{ needs.build.outputs.artifact_label }}.epub

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -170,7 +170,7 @@ jobs:
       contents: write
     steps:
       - name: Download verified workflow artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: offline-artifacts
           path: dist

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -170,7 +170,7 @@ jobs:
       contents: write
     steps:
       - name: Download verified workflow artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: offline-artifacts
           path: dist

--- a/python/tests/test_build_offline_book.py
+++ b/python/tests/test_build_offline_book.py
@@ -2,6 +2,8 @@ import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+
 
 def _load_build_offline_book():
     repo_root = Path(__file__).resolve().parents[2]
@@ -33,6 +35,97 @@ def test_normalize_for_pdf_does_not_touch_latex_commands():
     text = "q\\in Q\nQ\\in F\nA\\cap B\n"
     out = m.normalize_for_pdf(text)
     assert out == text
+
+
+def test_normalize_math_delimiters_for_pandoc():
+    m = _load_build_offline_book()
+    text = (
+        r"inline \\(x \\in \\mathbb{R}\\) end" "\n"
+        r"\\[" "\n" r"\\sum_i x_i" "\n" r"\\]" "\n"
+    )
+
+    out = m.normalize_math_delimiters_for_pandoc(text)
+
+    assert "inline $x \\in \\mathbb{R}$ end" in out
+    assert "$$\n\\sum_i x_i\n$$" in out
+
+
+def test_normalize_math_delimiters_preserves_single_commands_and_line_breaks():
+    m = _load_build_offline_book()
+    text = (
+        r"\\(x \in \mathbb{R}\\)" "\n"
+        r"\\[\begin{aligned}" "\n"
+        r"a & = b \\\\" "\n"
+        r"c & = d" "\n"
+        r"\end{aligned}\\]" "\n"
+    )
+
+    out = m.normalize_math_delimiters_for_pandoc(text)
+
+    assert "$x \\in \\mathbb{R}$" in out
+    assert "$$\\begin{aligned}\n" in out
+    assert "a & = b \\\\\n" in out
+    assert "\\end{aligned}$$" in out
+
+
+def test_normalize_math_delimiters_preserves_literal_parenthesis_before_closer():
+    m = _load_build_offline_book()
+
+    out = m.normalize_math_delimiters_for_pandoc(
+        r"\\(T(\\langle R\rangle\\)\\)" "\n"
+    )
+
+    assert out == "$T(\\langle R\\rangle)$\n"
+
+
+def test_normalize_math_delimiters_rejects_unclosed_math():
+    m = _load_build_offline_book()
+
+    with pytest.raises(ValueError, match="unclosed Web math delimiter"):
+        m.normalize_math_delimiters_for_pandoc(r"\\(x \\in X")
+
+
+def test_normalize_math_delimiters_preserves_code():
+    m = _load_build_offline_book()
+    text = (
+        "`\\\\(inline-code\\\\)` and \\\\(math\\\\)\n"
+        "```text\n\\\\(fenced\\\\)\n```\n"
+        "~~~text\n\\\\[fenced\\\\]\n~~~\n"
+    )
+
+    out = m.normalize_math_delimiters_for_pandoc(text)
+
+    assert "`\\\\(inline-code\\\\)` and $math$" in out
+    assert "```text\n\\\\(fenced\\\\)\n```" in out
+    assert "~~~text\n\\\\[fenced\\\\]\n~~~" in out
+
+
+def test_normalize_math_delimiters_preserves_multiline_code_span():
+    m = _load_build_offline_book()
+    text = (
+        "`code span starts\n"
+        "\\\\(still code\\\\)\n"
+        "` and \\\\(math\\\\)\n"
+    )
+
+    out = m.normalize_math_delimiters_for_pandoc(text)
+
+    assert out == (
+        "`code span starts\n"
+        "\\\\(still code\\\\)\n"
+        "` and $math$\n"
+    )
+
+
+def test_preprocess_real_chapter_six_normalizes_doubled_latex_commands():
+    m = _load_build_offline_book()
+    root = Path(__file__).resolve().parents[2]
+    chapter = (root / "docs/chapter-6/index.md").read_text(encoding="utf-8")
+
+    out = m.preprocess_markdown(chapter)
+
+    assert r"$z_v\in\mathbb{R}$" in out
+    assert r"$z_v\\in\\mathbb{R}$" not in out
 
 
 def test_publication_front_matter_uses_canonical_metadata():

--- a/python/tests/test_build_offline_book.py
+++ b/python/tests/test_build_offline_book.py
@@ -50,6 +50,19 @@ def test_normalize_math_delimiters_for_pandoc():
     assert "$$\n\\sum_i x_i\n$$" in out
 
 
+def test_normalize_single_backslash_math_delimiters_for_pandoc():
+    m = _load_build_offline_book()
+    text = (
+        r"inline \(p \in \mathbb{R}\) end" "\n"
+        r"\[\sum_i x_i\]" "\n"
+    )
+
+    out = m.normalize_math_delimiters_for_pandoc(text)
+
+    assert "inline $p \\in \\mathbb{R}$ end" in out
+    assert "$$\\sum_i x_i$$" in out
+
+
 def test_normalize_math_delimiters_preserves_single_commands_and_line_breaks():
     m = _load_build_offline_book()
     text = (
@@ -126,6 +139,17 @@ def test_preprocess_real_chapter_six_normalizes_doubled_latex_commands():
 
     assert r"$z_v\in\mathbb{R}$" in out
     assert r"$z_v\\in\\mathbb{R}$" not in out
+
+
+def test_preprocess_real_appendix_normalizes_single_backslash_delimiters():
+    m = _load_build_offline_book()
+    root = Path(__file__).resolve().parents[2]
+    appendix = (root / "docs/appendices/d.md").read_text(encoding="utf-8")
+
+    out = m.preprocess_markdown(appendix)
+
+    assert r"$p$ に対し" in out
+    assert r"\(p\)" not in out
 
 
 def test_publication_front_matter_uses_canonical_metadata():

--- a/python/tests/test_check_publication_metadata.py
+++ b/python/tests/test_check_publication_metadata.py
@@ -190,7 +190,7 @@ jobs:
       contents: write
     steps:
       - name: Download verified workflow artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: offline-artifacts
           path: dist

--- a/python/tests/test_check_publication_metadata.py
+++ b/python/tests/test_check_publication_metadata.py
@@ -94,24 +94,79 @@ Test Book Test Author 1.2.3 2026-07-16 2026-07-17
         root,
         ".github/workflows/release-artifacts.yml",
         r'''on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: false
+        type: string
   push:
     tags:
       - "v*"
+permissions:
+  contents: read
 jobs:
   build:
+    outputs:
+      release_tag: ${{ steps.release_target.outputs.release_tag }}
+      artifact_label: ${{ steps.artifact_label.outputs.value }}
     steps:
+      - name: Checkout release tooling
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          path: release-tooling
+          persist-credentials: false
+      - name: Resolve release target
+        id: release_target
+        env:
+          REQUESTED_RELEASE_TAG: ${{ inputs.release_tag || '' }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]] && [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then exit 1; fi
+          if [[ -n "${release_tag}" ]] && [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then true; fi
+          echo "target_ref=${target_ref}" >> "${GITHUB_OUTPUT}"
+          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+          echo "artifact_source=${artifact_source}" >> "${GITHUB_OUTPUT}"
+      - name: Checkout release source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.release_target.outputs.target_ref }}
+          path: release-source
+          fetch-depth: 0
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Verify canonical publication metadata and release tag
         run: |
-          python3 scripts/check_publication_metadata.py --release-tag "${GITHUB_REF_NAME}"
+          if [[ -n "${RELEASE_TAG}" ]]; then
+            source_head="$(git -C release-source rev-parse HEAD)"
+            tag_head="$(git -C release-source rev-list -n 1 "${RELEASE_TAG}")"
+            test "${source_head}" = "${tag_head}"
+            python3 release-tooling/scripts/check_publication_metadata.py \
+              --root release-source --contract-root release-tooling \
+              --release-tag "${RELEASE_TAG}"
+          else
+            python3 release-tooling/scripts/check_publication_metadata.py \
+              --root release-source --contract-root release-tooling
+          fi
       - name: Resolve filesystem-safe artifact label
         id: artifact_label
+        env:
+          ARTIFACT_SOURCE: ${{ steps.release_target.outputs.artifact_source }}
         run: |
-          artifact_label="${GITHUB_REF_NAME//\//-}"
+          artifact_label="${ARTIFACT_SOURCE//\//-}"
           echo "value=${artifact_label}" >> "${GITHUB_OUTPUT}"
+      - name: Build offline sources (Markdown)
+        run: |
+          python3 release-tooling/scripts/build_offline_book.py \
+            --docs-root release-source/docs \
+            --config release-source/docs/book-config.json \
+            --target epub --out dist/book.epub.md
+          python3 release-tooling/scripts/build_offline_book.py \
+            --docs-root release-source/docs \
+            --config release-source/docs/book-config.json \
+            --target pdf --out dist/book.pdf.md --asset-out dist
       - name: Build EPUB
         run: |
           artifact_label="${{ steps.artifact_label.outputs.value }}"
@@ -123,16 +178,29 @@ jobs:
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v7
         with:
+          name: offline-artifacts
           path: |
             dist/theoretical-computer-science-textbook-*.pdf
             dist/theoretical-computer-science-textbook-*.epub
+  publish:
+    needs: build
+    if: needs.build.outputs.release_tag != ''
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download verified workflow artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: offline-artifacts
+          path: dist
       - name: Create GitHub Release and upload assets
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ needs.build.outputs.release_tag }}
           files: |
-            dist/theoretical-computer-science-textbook-${{ steps.artifact_label.outputs.value }}.pdf
-            dist/theoretical-computer-science-textbook-${{ steps.artifact_label.outputs.value }}.epub
+            dist/theoretical-computer-science-textbook-${{ needs.build.outputs.artifact_label }}.pdf
+            dist/theoretical-computer-science-textbook-${{ needs.build.outputs.artifact_label }}.epub
 ''',
     )
     _write(
@@ -147,6 +215,14 @@ def build_publication_front_matter(cfg):
     return f"date: {release_date}\nlast_updated: {last_updated}"
 
 
+def normalize_math_delimiters_for_pandoc(text):
+    return text
+
+
+def preprocess_markdown(text):
+    return normalize_math_delimiters_for_pandoc(text)
+
+
 def main():
     cfg = load_book_config(Path(args.config))
     out_path.write_text(build_publication_front_matter(cfg) + combined_text)
@@ -158,6 +234,31 @@ def main():
 def test_happy_path_and_release_tag(tmp_path):
     root = _fixture(tmp_path)
     assert _module().main(["--root", str(root), "--release-tag", "v1.2.3"]) == 0
+
+
+def test_happy_path_without_release_tag(tmp_path):
+    root = _fixture(tmp_path)
+    assert _module().main(["--root", str(root)]) == 0
+
+
+def test_trusted_contract_root_does_not_execute_release_source_code(tmp_path):
+    source = _fixture(tmp_path / "source")
+    tooling = _fixture(tmp_path / "tooling")
+    _write(source, "scripts/check_publication_metadata.py", "raise RuntimeError('untrusted')")
+
+    assert (
+        _module().main(
+            [
+                "--root",
+                str(source),
+                "--contract-root",
+                str(tooling),
+                "--release-tag",
+                "v1.2.3",
+            ]
+        )
+        == 0
+    )
 
 
 def test_consumer_front_matter_drift_fails(tmp_path):
@@ -241,9 +342,91 @@ def test_workflow_requires_slash_safe_artifact_label(tmp_path):
     root = _fixture(tmp_path)
     workflow = root / ".github/workflows/release-artifacts.yml"
     text = workflow.read_text(encoding="utf-8").replace(
-        "GITHUB_REF_NAME//\\//-", "GITHUB_REF_NAME"
+        "ARTIFACT_SOURCE//\\//-", "ARTIFACT_SOURCE"
     )
     workflow.write_text(text, encoding="utf-8")
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_workflow_requires_manual_release_input_and_dual_checkout(tmp_path):
+    root = _fixture(tmp_path)
+    workflow = root / ".github/workflows/release-artifacts.yml"
+    text = workflow.read_text(encoding="utf-8")
+    text = text.replace("      release_tag:\n", "      retry_tag:\n")
+    text = text.replace(
+        "ref: ${{ steps.release_target.outputs.target_ref }}",
+        "ref: main",
+    )
+    workflow.write_text(text, encoding="utf-8")
+
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_workflow_requires_trusted_tooling_and_source_tag_equality(tmp_path):
+    root = _fixture(tmp_path)
+    workflow = root / ".github/workflows/release-artifacts.yml"
+    text = workflow.read_text(encoding="utf-8")
+    text = text.replace("          ref: main\n", "")
+    text = text.replace(
+        '          test "${source_head}" = "${tag_head}"\n',
+        "          true\n",
+    )
+    workflow.write_text(text, encoding="utf-8")
+
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_workflow_requires_artifact_only_source_validation(tmp_path):
+    root = _fixture(tmp_path)
+    workflow = root / ".github/workflows/release-artifacts.yml"
+    text = workflow.read_text(encoding="utf-8")
+    artifact_only = (
+        "          else\n"
+        "            python3 release-tooling/scripts/check_publication_metadata.py \\\n"
+        "              --root release-source --contract-root release-tooling\n"
+    )
+    workflow.write_text(text.replace(artifact_only, ""), encoding="utf-8")
+
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_workflow_rejects_release_source_code_execution(tmp_path):
+    root = _fixture(tmp_path)
+    workflow = root / ".github/workflows/release-artifacts.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        "python3 release-tooling/scripts/check_publication_metadata.py",
+        "python3 release-source/scripts/check_publication_metadata.py",
+    )
+    workflow.write_text(text, encoding="utf-8")
+
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_workflow_requires_read_build_and_isolated_write_publish(tmp_path):
+    root = _fixture(tmp_path)
+    workflow = root / ".github/workflows/release-artifacts.yml"
+    text = workflow.read_text(encoding="utf-8")
+    text = text.replace("permissions:\n  contents: read", "permissions:\n  contents: write", 1)
+    text = text.replace("      contents: write", "      contents: read")
+    workflow.write_text(text, encoding="utf-8")
+
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_workflow_requires_validated_release_gate_and_tag_name(tmp_path):
+    root = _fixture(tmp_path)
+    workflow = root / ".github/workflows/release-artifacts.yml"
+    text = workflow.read_text(encoding="utf-8")
+    text = text.replace(
+        "if: needs.build.outputs.release_tag != ''",
+        "if: github.event_name == 'workflow_dispatch'",
+    )
+    text = text.replace(
+        "tag_name: ${{ needs.build.outputs.release_tag }}",
+        "tag_name: v9.9.9",
+    )
+    workflow.write_text(text, encoding="utf-8")
+
     assert _module().main(["--root", str(root)]) == 1
 
 
@@ -259,4 +442,16 @@ def test_builder_contracts_in_comments_do_not_pass(tmp_path):
 value = 1
 """,
     )
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_builder_math_normalizer_must_be_on_preprocess_path(tmp_path):
+    root = _fixture(tmp_path)
+    builder = root / "scripts/build_offline_book.py"
+    text = builder.read_text(encoding="utf-8").replace(
+        "return normalize_math_delimiters_for_pandoc(text)",
+        "return text",
+    )
+    builder.write_text(text, encoding="utf-8")
+
     assert _module().main(["--root", str(root)]) == 1

--- a/python/tests/test_check_publication_metadata.py
+++ b/python/tests/test_check_publication_metadata.py
@@ -190,7 +190,7 @@ jobs:
       contents: write
     steps:
       - name: Download verified workflow artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: offline-artifacts
           path: dist

--- a/scripts/build_offline_book.py
+++ b/scripts/build_offline_book.py
@@ -65,6 +65,103 @@ def remove_stable_id_ial_lines(text: str) -> str:
     return "".join(out)
 
 
+def normalize_math_delimiters_for_pandoc(text: str) -> str:
+    """Convert Web math syntax to Pandoc `$`/`$$` syntax.
+
+    The Web source uses doubled delimiters (``\\\\(``, ``\\\\[``) and contains
+    both single- and double-escaped LaTeX commands. Pandoc needs one backslash
+    for a command and two for an ``aligned`` line break, so even-length runs are
+    halved only while inside math. Fenced blocks and inline code are preserved.
+    """
+    fence_character: str | None = None
+    fence_length = 0
+    math_closer: str | None = None
+    code_delimiter: str | None = None
+    out: list[str] = []
+    for line in text.splitlines(keepends=True):
+        fence = re.match(r"^\s*(`{3,}|~{3,})", line)
+        if fence_character is not None and math_closer is None and code_delimiter is None:
+            out.append(line)
+            if (
+                fence
+                and fence.group(1)[0] == fence_character
+                and len(fence.group(1)) >= fence_length
+            ):
+                fence_character = None
+                fence_length = 0
+            continue
+        if fence and math_closer is None and code_delimiter is None:
+            fence_character = fence.group(1)[0]
+            fence_length = len(fence.group(1))
+            out.append(line)
+            continue
+
+        position = 0
+        while position < len(line):
+            if math_closer is not None:
+                if line.startswith(math_closer + math_closer, position):
+                    # A few Web formulas encode a literal closing parenthesis
+                    # with the same doubled token immediately before the real
+                    # math closer (``...\\\\)\\\\)``). Keep the first character
+                    # inside math and let the second token close the span.
+                    out.append(math_closer[-1])
+                    position += len(math_closer)
+                    continue
+                if line.startswith(math_closer, position):
+                    out.append("$$" if math_closer == "\\\\]" else "$")
+                    position += len(math_closer)
+                    math_closer = None
+                    continue
+                if line[position] == "\\":
+                    run_end = position + 1
+                    while run_end < len(line) and line[run_end] == "\\":
+                        run_end += 1
+                    run_length = run_end - position
+                    normalized_length = run_length // 2 if run_length % 2 == 0 else run_length
+                    out.append("\\" * normalized_length)
+                    position = run_end
+                    continue
+                out.append(line[position])
+                position += 1
+                continue
+
+            if code_delimiter is not None:
+                if line.startswith(code_delimiter, position):
+                    out.append(code_delimiter)
+                    position += len(code_delimiter)
+                    code_delimiter = None
+                else:
+                    out.append(line[position])
+                    position += 1
+                continue
+
+            if line[position] == "`":
+                run_end = position + 1
+                while run_end < len(line) and line[run_end] == "`":
+                    run_end += 1
+                code_delimiter = line[position:run_end]
+                out.append(code_delimiter)
+                position = run_end
+                continue
+
+            if line.startswith("\\\\(", position):
+                out.append("$")
+                math_closer = "\\\\)"
+                position += 3
+                continue
+            if line.startswith("\\\\[", position):
+                out.append("$$")
+                math_closer = "\\\\]"
+                position += 3
+                continue
+
+            out.append(line[position])
+            position += 1
+    if math_closer is not None:
+        raise ValueError(f"unclosed Web math delimiter; expected {math_closer!r}")
+    return "".join(out)
+
+
 def load_book_config(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -137,6 +234,7 @@ def preprocess_markdown(text: str) -> str:
     text = strip_front_matter(text)
     text = rewrite_liquid_relative_url(text)
     text = remove_stable_id_ial_lines(text)
+    text = normalize_math_delimiters_for_pandoc(text)
     return text
 
 

--- a/scripts/build_offline_book.py
+++ b/scripts/build_offline_book.py
@@ -68,10 +68,11 @@ def remove_stable_id_ial_lines(text: str) -> str:
 def normalize_math_delimiters_for_pandoc(text: str) -> str:
     """Convert Web math syntax to Pandoc `$`/`$$` syntax.
 
-    The Web source uses doubled delimiters (``\\\\(``, ``\\\\[``) and contains
-    both single- and double-escaped LaTeX commands. Pandoc needs one backslash
-    for a command and two for an ``aligned`` line break, so even-length runs are
-    halved only while inside math. Fenced blocks and inline code are preserved.
+    The Web source contains both single and doubled delimiters (``\\(``,
+    ``\\\\(``, ``\\[``, ``\\\\[``) and both single- and double-escaped LaTeX
+    commands. Pandoc needs one backslash for a command and two for an ``aligned``
+    line break, so even-length runs are halved only while inside math. Fenced
+    blocks and inline code are preserved.
     """
     fence_character: str | None = None
     fence_length = 0
@@ -108,7 +109,7 @@ def normalize_math_delimiters_for_pandoc(text: str) -> str:
                     position += len(math_closer)
                     continue
                 if line.startswith(math_closer, position):
-                    out.append("$$" if math_closer == "\\\\]" else "$")
+                    out.append("$$" if math_closer.endswith("]") else "$")
                     position += len(math_closer)
                     math_closer = None
                     continue
@@ -153,6 +154,16 @@ def normalize_math_delimiters_for_pandoc(text: str) -> str:
                 out.append("$$")
                 math_closer = "\\\\]"
                 position += 3
+                continue
+            if line.startswith("\\(", position):
+                out.append("$")
+                math_closer = "\\)"
+                position += 2
+                continue
+            if line.startswith("\\[", position):
+                out.append("$$")
+                math_closer = "\\]"
+                position += 2
                 continue
 
             out.append(line[position])

--- a/scripts/check_publication_metadata.py
+++ b/scripts/check_publication_metadata.py
@@ -272,12 +272,69 @@ def validate_workflow(root: Path, errors: list[str]) -> None:
     )
     if not re.search(r"(?m)^\s{4}tags:\s*\n\s{6}-\s*[\"']?v\*[\"']?\s*$", active):
         errors.append(f"{path}: missing active v* tag trigger")
+    if not re.search(r"(?m)^permissions:\s*\n  contents:\s*read\s*$", active):
+        errors.append(f"{path}: workflow default permissions must be contents: read")
+    dispatch_match = re.search(
+        r"(?ms)^  workflow_dispatch:\s*\n(?P<body>.*?)(?=^  [A-Za-z][A-Za-z_-]*:|^env:|^permissions:|^jobs:)",
+        active,
+    )
+    dispatch = dispatch_match.group("body") if dispatch_match else ""
+    for name, pattern in (
+        ("release_tag input", r"(?m)^      release_tag:\s*$"),
+        ("optional release_tag", r"(?m)^        required:\s*false\s*$"),
+        ("string release_tag", r"(?m)^        type:\s*string\s*$"),
+    ):
+        if not re.search(pattern, dispatch):
+            errors.append(f"{path}: workflow_dispatch is missing {name}")
 
     steps = re.findall(r"(?ms)^      - (.*?)(?=^      - |\Z)", active)
 
     def step_named(name: str) -> str:
         prefix = f"name: {name}"
         return next((step for step in steps if step.startswith(prefix)), "")
+
+    build_match = re.search(r"(?ms)^  build:\s*\n(?P<body>.*?)(?=^  publish:)", active)
+    build_job = build_match.group("body") if build_match else ""
+    for name, pattern in (
+        ("release_tag job output", r"(?m)^      release_tag:\s*\$\{\{\s*steps\.release_target\.outputs\.release_tag\s*\}\}\s*$"),
+        ("artifact_label job output", r"(?m)^      artifact_label:\s*\$\{\{\s*steps\.artifact_label\.outputs\.value\s*\}\}\s*$"),
+    ):
+        if not re.search(pattern, build_job):
+            errors.append(f"{path}: build job missing {name}")
+
+    tooling_checkout = step_named("Checkout release tooling")
+    for name, pattern in (
+        ("checkout action", r"(?m)^        uses: actions/checkout@v\d+\s*$"),
+        ("trusted main ref", r"(?m)^\s+ref:\s*main\s*$"),
+        ("tooling path", r"(?m)^\s+path:\s*release-tooling\s*$"),
+        ("credential isolation", r"(?m)^\s+persist-credentials:\s*false\s*$"),
+    ):
+        if not re.search(pattern, tooling_checkout):
+            errors.append(f"{path}: tooling checkout missing {name}")
+
+    target_step = step_named("Resolve release target")
+    for name, pattern in (
+        ("release_target id", r"(?m)^        id:\s*release_target\s*$"),
+        ("safe input environment", r"inputs\.release_tag\s*\|\|\s*''"),
+        ("main-only manual dispatch", r'GITHUB_EVENT_NAME\}" == "workflow_dispatch".*GITHUB_REF\}" != "refs/heads/main"'),
+        ("semantic-version validation", r"\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$"),
+        ("target_ref output", r'echo "target_ref=\$\{target_ref\}" >> "\$\{GITHUB_OUTPUT\}"'),
+        ("release_tag output", r'echo "release_tag=\$\{release_tag\}" >> "\$\{GITHUB_OUTPUT\}"'),
+        ("artifact_source output", r'echo "artifact_source=\$\{artifact_source\}" >> "\$\{GITHUB_OUTPUT\}"'),
+    ):
+        if not re.search(pattern, target_step):
+            errors.append(f"{path}: release-target step missing {name}")
+
+    source_checkout = step_named("Checkout release source")
+    for name, pattern in (
+        ("checkout action", r"(?m)^        uses: actions/checkout@v\d+\s*$"),
+        ("validated target ref", r"steps\.release_target\.outputs\.target_ref"),
+        ("source path", r"(?m)^\s+path:\s*release-source\s*$"),
+        ("full tag history", r"(?m)^\s+fetch-depth:\s*0\s*$"),
+        ("credential isolation", r"(?m)^\s+persist-credentials:\s*false\s*$"),
+    ):
+        if not re.search(pattern, source_checkout):
+            errors.append(f"{path}: source checkout missing {name}")
 
     setup_step = step_named("Setup Python")
     if not (
@@ -287,12 +344,38 @@ def validate_workflow(root: Path, errors: list[str]) -> None:
         errors.append(f"{path}: deterministic Python 3.12 setup is missing")
 
     metadata_step = step_named("Verify canonical publication metadata and release tag")
-    if not re.search(
-        r"(?m)^\s+python3 scripts/check_publication_metadata\.py --release-tag "
-        r'"\$\{GITHUB_REF_NAME\}"\s*$',
-        metadata_step,
+    for name, pattern in (
+        (
+            "trusted checker",
+            r"python3 release-tooling/scripts/check_publication_metadata\.py\s+\\\s*\n"
+            r"\s+--root release-source --contract-root release-tooling",
+        ),
+        (
+            "checked-out source commit",
+            r'git -C release-source rev-parse HEAD',
+        ),
+        (
+            "immutable tag target validation",
+            r'git -C release-source rev-list -n 1 "\$\{RELEASE_TAG\}"',
+        ),
+        (
+            "immutable source/tag equality",
+            r'test "\$\{source_head\}" = "\$\{tag_head\}"',
+        ),
+        (
+            "release tag validation",
+            r'--release-tag "\$\{RELEASE_TAG\}"',
+        ),
+        (
+            "artifact-only source validation",
+            r"else\s*\n\s+python3 release-tooling/scripts/check_publication_metadata\.py\s+\\\s*\n"
+            r"\s+--root release-source --contract-root release-tooling\s*\n\s+fi\s*$",
+        ),
     ):
-        errors.append(f"{path}: metadata step must validate the pushed tag")
+        if not re.search(pattern, metadata_step):
+            errors.append(f"{path}: metadata step missing {name}")
+    if "release-source/scripts/" in metadata_step:
+        errors.append(f"{path}: metadata step must not execute release-source code")
     setup_index = next(
         (index for index, step in enumerate(steps) if step.startswith("name: Setup Python")),
         None,
@@ -310,11 +393,23 @@ def validate_workflow(root: Path, errors: list[str]) -> None:
 
     label_step = step_named("Resolve filesystem-safe artifact label")
     for name, pattern in (
-        ("slash sanitization", r"GITHUB_REF_NAME//\\//-"),
+        ("validated artifact source", r"steps\.release_target\.outputs\.artifact_source"),
+        ("slash sanitization", r"ARTIFACT_SOURCE//\\//-"),
         ("artifact label output", r'echo "value=\$\{artifact_label\}" >> "\$\{GITHUB_OUTPUT\}"'),
     ):
         if not re.search(pattern, label_step):
             errors.append(f"{path}: artifact-label step missing {name}")
+
+    source_build_step = step_named("Build offline sources (Markdown)")
+    for name, pattern in (
+        ("current builder", r"release-tooling/scripts/build_offline_book\.py"),
+        ("tag docs root", r"--docs-root release-source/docs"),
+        ("tag config", r"--config release-source/docs/book-config\.json"),
+        ("EPUB preprocessing", r"--target epub --out dist/book\.epub\.md"),
+        ("PDF preprocessing", r"--target pdf --out dist/book\.pdf\.md --asset-out dist"),
+    ):
+        if not re.search(pattern, source_build_step):
+            errors.append(f"{path}: offline source build missing {name}")
 
     output_reference = r"steps\.artifact_label\.outputs\.value"
     for format_name in ("EPUB", "PDF"):
@@ -337,15 +432,37 @@ def validate_workflow(root: Path, errors: list[str]) -> None:
         if not re.search(rf"(?m)^\s+dist/theoretical-computer-science-textbook-\*\.{suffix}\s*$", upload_step):
             errors.append(f"{path}: workflow artifact upload omits {suffix.upper()}")
 
+    publish_match = re.search(r"(?ms)^  publish:\s*\n(?P<body>.*)\Z", active)
+    publish_job = publish_match.group("body") if publish_match else ""
+    for name, pattern in (
+        ("build dependency", r"(?m)^    needs:\s*build\s*$"),
+        ("validated release gate", r"needs\.build\.outputs\.release_tag\s*!=\s*''"),
+        ("actions read permission", r"(?m)^      actions:\s*read\s*$"),
+        ("contents write permission", r"(?m)^      contents:\s*write\s*$"),
+    ):
+        if not re.search(pattern, publish_job):
+            errors.append(f"{path}: isolated publish job missing {name}")
+
+    download_step = step_named("Download verified workflow artifacts")
+    if not (
+        re.search(r"(?m)^        uses: actions/download-artifact@v\d+\s*$", download_step)
+        and re.search(r"(?m)^\s+name:\s*offline-artifacts\s*$", download_step)
+        and re.search(r"(?m)^\s+path:\s*dist\s*$", download_step)
+    ):
+        errors.append(f"{path}: isolated publish job must download offline-artifacts")
+
     release_step = step_named("Create GitHub Release and upload assets")
     if not re.search(r"(?m)^        uses: softprops/action-gh-release@v\d+\s*$", release_step):
         errors.append(f"{path}: active GitHub Release action is missing")
-    if not re.search(r"startsWith\(github\.ref, 'refs/tags/'\)", release_step):
-        errors.append(f"{path}: GitHub Release action must be tag-only")
+    if not re.search(
+        r"tag_name:\s*\$\{\{\s*needs\.build\.outputs\.release_tag\s*\}\}",
+        release_step,
+    ):
+        errors.append(f"{path}: GitHub Release action must publish the validated tag")
     for suffix in ("pdf", "epub"):
         expected = (
             "dist/theoretical-computer-science-textbook-"
-            "${{ steps.artifact_label.outputs.value }}."
+            "${{ needs.build.outputs.artifact_label }}."
             f"{suffix}"
         )
         if expected not in release_step:
@@ -379,6 +496,20 @@ def validate_builder(root: Path, errors: list[str]) -> None:
             if marker not in helper_source:
                 errors.append(f"{path}: publication helper omits {marker!r}")
 
+    normalizer = functions.get("normalize_math_delimiters_for_pandoc")
+    if normalizer is None:
+        errors.append(f"{path}: Pandoc math normalizer is missing")
+    preprocess = functions.get("preprocess_markdown")
+    if preprocess is None:
+        errors.append(f"{path}: Markdown preprocessing entry point is missing")
+    elif not any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "normalize_math_delimiters_for_pandoc"
+        for node in ast.walk(preprocess)
+    ):
+        errors.append(f"{path}: Markdown preprocessing does not call the Pandoc math normalizer")
+
     loads_canonical_config = False
     writes_publication_front_matter = False
     for node in ast.walk(tree):
@@ -402,9 +533,15 @@ def validate_builder(root: Path, errors: list[str]) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path.cwd(), help="repository root")
+    parser.add_argument(
+        "--contract-root",
+        type=Path,
+        help="trusted root containing the release workflow and offline builder",
+    )
     parser.add_argument("--release-tag", help="tag supplied by the release workflow")
     args = parser.parse_args(argv)
     root, errors = args.root.resolve(), []
+    contract_root = args.contract_root.resolve() if args.contract_root else root
     cfg = validate_config(root, errors)
     if cfg is not None:
         publication = cfg.get("publication")
@@ -414,8 +551,8 @@ def main(argv: list[str] | None = None) -> int:
                 f"--release-tag {args.release_tag!r} does not match canonical {canonical_tag!r}"
             )
         validate_consumers(root, cfg, errors)
-    validate_workflow(root, errors)
-    validate_builder(root, errors)
+    validate_workflow(contract_root, errors)
+    validate_builder(contract_root, errors)
     if errors:
         print("publication metadata check failed:", file=sys.stderr)
         print("\n".join(f"- {error}" for error in errors), file=sys.stderr)


### PR DESCRIPTION
## 概要

Issue #393 の `v1.2.0` Release Artifacts runで失敗したPDF生成を修復し、既存のannotated tagを移動せず再実行できる契約を追加します。

## 変更内容

- Web用の `\\\\(...\\\\)` / `\\\\[...\\\\]` をPandoc mathへ正規化
- 数式内のsingle/double/four-backslashを、LaTeX commandと改行の意味を保って正規化
- fenced code、単一行/複数行code spanを非変換に維持
- 未閉鎖数式、重複closer、実章6の `z_v\\in\\mathbb{R}` を回帰テスト化
- `workflow_dispatch.release_tag` による既存tag再実行を追加
- trusted `main` toolingとimmutable tagged sourceを分離checkout
- tagged sourceはデータとしてのみ扱い、trusted checker/builder以外のcodeを実行しない
- buildを`contents: read`、publishを別jobの`contents: write`に分離
- source/tag commit一致、artifact-only経路、release gate、権限境界をmetadata checkerで検証

## 検証

- `npm test`
- `npm run spellcheck`（72 files / 0 issues）
- `make test`（72 passed）
- index/search generated checks
- docs regression / notation lint
- Jekyll production build + HTML notation check
- immutable `v1.2.0` archiveをcurrent trusted toolingで処理するローカル契約試験
- publication metadata checker negative fixtures
- security reviewer / correctness reviewer: Blocker・High・Medium残存なし

## Merge後の手順

1. `Release Artifacts` をmainから入力なしで実行し、PDF/EPUB buildをartifact-onlyで確認
2. 同workflowを `release_tag=v1.2.0` で実行
3. tag targetが `580ae13f525b57e75c4e16dbc217a3fd60c211d0` のままであることを再確認
4. Release assets確認後、読者向け「Release準備中」文言を別PRで「提供中」へ更新

Refs #393
