### PR TITLE
fix: Pandoc inline数式の境界空白を除去する

### DIFF
--- a/python/tests/test_build_offline_book.py
+++ b/python/tests/test_build_offline_book.py
@@ -63,6 +63,16 @@ def test_normalize_single_backslash_math_delimiters_for_pandoc():
     assert "$$\\sum_i x_i$$" in out
 
 
+def test_normalize_inline_math_trims_invalid_boundary_spaces():
+    m = _load_build_offline_book()
+
+    out = m.normalize_math_delimiters_for_pandoc(
+        r"double \\( \lvert X \rvert \\) and single \( p \)" "\n"
+    )
+
+    assert out == "double $\\lvert X \\rvert$ and single $p$\n"
+
+
 def test_normalize_math_delimiters_preserves_single_commands_and_line_breaks():
     m = _load_build_offline_book()
     text = (
@@ -139,6 +149,16 @@ def test_preprocess_real_chapter_six_normalizes_doubled_latex_commands():
 
     assert r"$z_v\in\mathbb{R}$" in out
     assert r"$z_v\\in\\mathbb{R}$" not in out
+
+
+def test_preprocess_real_chapter_two_produces_valid_pandoc_inline_math():
+    m = _load_build_offline_book()
+    root = Path(__file__).resolve().parents[2]
+    chapter = (root / "docs/chapter-2/index.md").read_text(encoding="utf-8")
+
+    out = m.preprocess_markdown(chapter)
+
+    assert r"**定理 2.10** $\lvert \Sigma \rvert \ge 2$ を仮定" in out
 
 
 def test_preprocess_real_appendix_normalizes_single_backslash_delimiters():

--- a/scripts/build_offline_book.py
+++ b/scripts/build_offline_book.py
@@ -109,6 +109,9 @@ def normalize_math_delimiters_for_pandoc(text: str) -> str:
                     position += len(math_closer)
                     continue
                 if line.startswith(math_closer, position):
+                    if math_closer.endswith(")"):
+                        while out and out[-1] in (" ", "\t"):
+                            out.pop()
                     out.append("$$" if math_closer.endswith("]") else "$")
                     position += len(math_closer)
                     math_closer = None
@@ -149,6 +152,8 @@ def normalize_math_delimiters_for_pandoc(text: str) -> str:
                 out.append("$")
                 math_closer = "\\\\)"
                 position += 3
+                while position < len(line) and line[position] in (" ", "\t"):
+                    position += 1
                 continue
             if line.startswith("\\\\[", position):
                 out.append("$$")
@@ -159,6 +164,8 @@ def normalize_math_delimiters_for_pandoc(text: str) -> str:
                 out.append("$")
                 math_closer = "\\)"
                 position += 2
+                while position < len(line) and line[position] in (" ", "\t"):
+                    position += 1
                 continue
             if line.startswith("\\[", position):
                 out.append("$$")


### PR DESCRIPTION
## 概要

PR #418 merge後のartifact-only Release dry runで判明した、Pandoc inline math境界の追加修正です。

## 原因

Web用 `\\(...\\)` / `\\\\(...\\\\)` の内側に水平空白がある場合、preprocessorが `$ <formula> $` を生成していました。Pandocはこれをinline mathとして認識せず、生成LaTeXの `\\$ \\lvert` がmath mode外になりPDF buildが失敗しました。

- failed run: https://github.com/itdojp/theoretical-computer-science-textbook/actions/runs/29465213098
- error: `Missing $ inserted`
- generated LaTeX: `\\textbf{定理 2.10} \\$ \\lvert`

## 変更

- inline math opener直後の水平空白を除去
- inline math closer直前の水平空白を除去
- single/double-backslash delimiterの両方を検証
- 実第2章 定理2.10を回帰fixtureとして追加

## 検証

- targeted 36 tests passed
- full `make test`: 76 passed
- `npm test` / audit 0
- index/search checks、docs regression、notation lint
- Jekyll production build + HTML notation check
- offline Markdown全体のinline math bodyについて、先頭/末尾空白0を決定的に監査

## Merge後

再度artifact-only dry runを実施し、PDF/EPUB成功後にのみ `release_tag=v1.2.0` を実行します。

Refs #393
