### PR TITLE
docs: v1.2.0 Release公開状態を読者案内へ反映する

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## 読者向け導線
 
 - 公開サイト（正本）: https://itdojp.github.io/theoretical-computer-science-textbook/
-- Web公開版: 1.2.0（2026-07-16更新）。固定版tag `v1.2.0`はRelease準備中です。
+- Web公開版: 1.2.0（2026-07-16更新）。固定版は[GitHub Releasesの`v1.2.0`](https://github.com/itdojp/theoretical-computer-science-textbook/releases/tag/v1.2.0)で提供中です。
 - 本書の目的と構成: https://itdojp.github.io/theoretical-computer-science-textbook/introduction/purpose/
 - 学習の進め方: https://itdojp.github.io/theoretical-computer-science-textbook/introduction/learning-guide/
 - オフライン版の提供状況: https://itdojp.github.io/theoretical-computer-science-textbook/downloads/
@@ -79,7 +79,7 @@
 ## 配布ポリシー
 
 - **Web版** を正本とします。
-- **公式 PDF / EPUB** は `v1.2.0` tagの公開後、[GitHub Releases](https://github.com/itdojp/theoretical-computer-science-textbook/releases)で版ごとに提供します。Release完了まではWeb版を利用してください。
+- **公式 PDF / EPUB** は[GitHub Releasesの`v1.2.0`](https://github.com/itdojp/theoretical-computer-science-textbook/releases/tag/v1.2.0)で提供しています。
 - Release artifact は固定版のオフライン閲覧用です。訂正を含む最新版は引き続きWeb版を参照してください。
 - 版番号、Release tag、成果物の対応は公開サイトの[更新履歴](https://itdojp.github.io/theoretical-computer-science-textbook/changelog/)と[ダウンロード案内](https://itdojp.github.io/theoretical-computer-science-textbook/downloads/)で確認できます。
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,6 +5,7 @@ version: "1.2.0"
 release_date: "2026-07-16"
 last_updated: "2026-07-16"
 release_tag: "v1.2.0"
+release_status: "published"
 lang: "ja"
 
 # GitHub Pages設定

--- a/docs/assets/search-data.json
+++ b/docs/assets/search-data.json
@@ -68,7 +68,7 @@
       "url": "/theoretical-computer-science-textbook/appendices/"
     },
     {
-      "excerpt": "更新履歴（CHANGELOG） Web版はmainブランチから継続公開し、版番号を固定したPDF/EPUBは tagのRelease完了後に提供します。ここではコミット列挙ではなく、読者へ影響する変更を版ごとに整理します。 Unreleased - 現在、次版向けとして確定した読者向け変更はありません。 1.2.0 — 2026-07-16 読み始め方と再参照性 - 第一読者・前提知識・非対象読者をfront matterに明示し、通読",
+      "excerpt": "更新履歴（CHANGELOG） Web版はmainブランチから継続公開し、版番号を固定したPDF/EPUBは Releaseで提供しています。ここではコミット列挙ではなく、読者へ影響する変更を版ごとに整理します。 Unreleased - 現在、次版向けとして確定した読者向け変更はありません。 1.2.0 — 2026-07-16 読み始め方と再参照性 - 第一読者・前提知識・非対象読者をfront matterに明示し、通読、講義補助",
       "source_path": "docs/changelog/index.md",
       "title": "更新履歴（CHANGELOG）",
       "url": "/theoretical-computer-science-textbook/changelog/"
@@ -146,7 +146,7 @@
       "url": "/theoretical-computer-science-textbook/chapter-9/"
     },
     {
-      "excerpt": "オフライン版（PDF/EPUB） 本書はWeb版を内容の正本とし、固定版をオフラインで読むためのPDF/EPUBをGitHub Releasesで提供します。 はRelease準備中であり、完了まではWeb版を利用してください。 クイックナビ - 現在の提供状況 - 読者向けの案内 - 版と成果物の関係 - ローカルでの生成（開発者・コントリビューター向け） - Release運用 現在の提供状況 - Web版 : 利用できます。訂正を",
+      "excerpt": "オフライン版（PDF/EPUB） 本書はWeb版を内容の正本とし、固定版をオフラインで読むためのPDF/EPUBをGitHub Releasesで提供します。 の公式成果物は公開済みです。 クイックナビ - 現在の提供状況 - 読者向けの案内 - 版と成果物の関係 - ローカルでの生成（開発者・コントリビューター向け） - Release運用 現在の提供状況 - Web版 : 利用できます。訂正を含む最新版は公開サイトを正本としてくださ",
       "source_path": "docs/downloads/index.md",
       "title": "オフライン版（PDF/EPUB）",
       "url": "/theoretical-computer-science-textbook/downloads/"

--- a/docs/book-config.json
+++ b/docs/book-config.json
@@ -7,6 +7,7 @@
     "release_date": "2026-07-16",
     "last_updated": "2026-07-16",
     "release_tag": "v1.2.0",
+    "release_status": "published",
     "web_is_canonical": true,
     "official_artifacts": ["pdf", "epub"]
   },

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -5,7 +5,7 @@ title: "更新履歴（CHANGELOG）"
 
 # 更新履歴（CHANGELOG）
 
-Web版はmainブランチから継続公開し、版番号を固定したPDF/EPUBは`v1.2.0` tagのRelease完了後に提供します。ここではコミット列挙ではなく、読者へ影響する変更を版ごとに整理します。
+Web版はmainブランチから継続公開し、版番号を固定したPDF/EPUBは[`v1.2.0` Release](https://github.com/itdojp/theoretical-computer-science-textbook/releases/tag/v1.2.0)で提供しています。ここではコミット列挙ではなく、読者へ影響する変更を版ごとに整理します。
 
 ## Unreleased
 
@@ -36,6 +36,7 @@ Web版はmainブランチから継続公開し、版番号を固定したPDF/EPU
 - モバイルsidebarの重なりと表示条件を修正し、全公開ページのnavigation coverageを検査するようにしました。
 - notation、生成索引、HTML、リンク、docs禁止物、依存監査、Jekyll buildをCIで継続検査し、品質ゲート自体の配線も検証するようにしました。
 - 書名、版、著者、更新日、Release tagをcanonical metadataへ統合し、公式PDF/EPUBを安全に公開するRelease契約を整備しました。
+- `v1.2.0`のPDF/EPUBを2026-07-16にGitHub Releaseで公開しました。
 
 ## 1.1.2
 

--- a/docs/downloads/index.md
+++ b/docs/downloads/index.md
@@ -5,7 +5,7 @@ title: "オフライン版（PDF/EPUB）"
 
 # オフライン版（PDF/EPUB）
 
-本書はWeb版を内容の正本とし、固定版をオフラインで読むためのPDF/EPUBをGitHub Releasesで提供します。`v1.2.0`はRelease準備中であり、完了まではWeb版を利用してください。
+本書はWeb版を内容の正本とし、固定版をオフラインで読むためのPDF/EPUBをGitHub Releasesで提供します。`v1.2.0`の公式成果物は公開済みです。
 
 ## クイックナビ {#downloads-quick-nav}
 
@@ -18,9 +18,11 @@ title: "オフライン版（PDF/EPUB）"
 ## 現在の提供状況 {#downloads-current}
 
 - **Web版**: 利用できます。訂正を含む最新版は公開サイトを正本としてください。
-- **公式 PDF / EPUB**: `v1.2.0` tagのRelease完了後に提供します。
-- **配布先**: [GitHub Releases](https://github.com/itdojp/theoretical-computer-science-textbook/releases)
-- **配布予定tag**: `v1.2.0`
+- **公式 PDF / EPUB**: `v1.2.0`を提供中です。
+- **配布先**: [`v1.2.0` Release](https://github.com/itdojp/theoretical-computer-science-textbook/releases/tag/v1.2.0)
+- **PDF**: [theoretical-computer-science-textbook-v1.2.0.pdf](https://github.com/itdojp/theoretical-computer-science-textbook/releases/download/v1.2.0/theoretical-computer-science-textbook-v1.2.0.pdf)
+- **EPUB**: [theoretical-computer-science-textbook-v1.2.0.epub](https://github.com/itdojp/theoretical-computer-science-textbook/releases/download/v1.2.0/theoretical-computer-science-textbook-v1.2.0.epub)
+- **Release tag**: `v1.2.0`
 
 ## 読者向けの案内 {#downloads-reader}
 
@@ -35,7 +37,7 @@ title: "オフライン版（PDF/EPUB）"
 | --- | --- |
 | Release tag | `v1.2.0` |
 | 公開日 | 2026-07-16 |
-| 公式成果物 | PDF / EPUB（Release準備中） |
+| 公式成果物 | PDF / EPUB（提供中） |
 | 内容の正本 | Web版 |
 | 署名 | 未提供 |
 
@@ -63,7 +65,7 @@ python3 scripts/build_offline_book.py --target pdf --out dist/book.pdf.md --asse
 pandoc dist/book.pdf.md -o dist/theoretical-computer-science-textbook.pdf --toc --resource-path=dist --pdf-engine=xelatex
 ```
 
-公式成果物は `.github/workflows/release-artifacts.yml` がtag push時に生成します。ローカル生成物は公式Release assetではありません。
+公式成果物は `.github/workflows/release-artifacts.yml` がtag push時、または既存tagを指定した承認済みmanual retry時に生成します。ローカル生成物は公式Release assetではありません。
 
 ## Release運用 {#downloads-future}
 

--- a/python/tests/test_check_publication_metadata.py
+++ b/python/tests/test_check_publication_metadata.py
@@ -30,6 +30,7 @@ def _fixture(tmp_path: Path) -> Path:
             "release_date": "2026-07-16",
             "last_updated": "2026-07-17",
             "release_tag": "v1.2.3",
+            "release_status": "published",
             "web_is_canonical": True,
             "official_artifacts": ["pdf", "epub"],
         },
@@ -48,6 +49,7 @@ def _fixture(tmp_path: Path) -> Path:
                 'release_date: "2026-07-16"',
                 'last_updated: "2026-07-17"',
                 'release_tag: "v1.2.3"',
+                'release_status: "published"',
             )
         ),
     )
@@ -77,14 +79,29 @@ Test Book Test Author 1.2.3 2026-07-16 2026-07-17
     _write(root, "package.json", json.dumps(package))
     _write(root, "package-lock.json", json.dumps(package_lock))
     _write(root, "CLAUDE.md", "Test Book")
+    release_url = (
+        "https://github.com/itdojp/theoretical-computer-science-textbook/"
+        "releases/tag/v1.2.3"
+    )
     _write(
         root,
         "README.md",
-        "Test Book 1.2.3 2026-07-16 v1.2.3 Web版 公式 PDF / EPUB GitHub Releases",
+        "Test Book 1.2.3 2026-07-16 v1.2.3 Web版 公式 PDF / EPUB "
+        f"GitHub Releases {release_url}",
     )
 
-    changelog = "## 1.2.3 — 2026-07-16\nv1.2.3 技術内容の監査と訂正 品質保証"
-    downloads = "1.2.3 2026-07-16 v1.2.3 PDF EPUB Web版 GitHub Releases"
+    changelog = (
+        "## 1.2.3 — 2026-07-16\n"
+        f"v1.2.3 技術内容の監査と訂正 品質保証 {release_url}"
+    )
+    asset_base = (
+        "https://github.com/itdojp/theoretical-computer-science-textbook/"
+        "releases/download/v1.2.3/theoretical-computer-science-textbook-v1.2.3"
+    )
+    downloads = (
+        "1.2.3 2026-07-16 v1.2.3 PDF EPUB Web版 GitHub Releases "
+        f"{release_url} {asset_base}.pdf {asset_base}.epub"
+    )
     for relative in ("docs/changelog/index.md", "src/changelog/index.md"):
         _write(root, relative, changelog)
     for relative in ("docs/downloads/index.md", "src/downloads/index.md"):
@@ -231,6 +248,40 @@ def main():
     return root
 
 
+def _set_release_status(root: Path, status: str) -> None:
+    config_path = root / "docs/book-config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["publication"]["release_status"] = status
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    config_yml = root / "docs/_config.yml"
+    config_yml.write_text(
+        config_yml.read_text(encoding="utf-8").replace(
+            'release_status: "published"', f'release_status: "{status}"'
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_preparing_reader_copy(root: Path) -> None:
+    _write(
+        root,
+        "README.md",
+        "Test Book 1.2.3 2026-07-16 v1.2.3 Web版 公式 PDF / EPUB "
+        "GitHub Releases Release準備中",
+    )
+    changelog = (
+        "## 1.2.3 — 2026-07-16\n"
+        "v1.2.3 技術内容の監査と訂正 品質保証 Release完了後"
+    )
+    downloads = (
+        "1.2.3 2026-07-16 v1.2.3 PDF EPUB Web版 GitHub Releases 配布予定tag"
+    )
+    for relative in ("docs/changelog/index.md", "src/changelog/index.md"):
+        _write(root, relative, changelog)
+    for relative in ("docs/downloads/index.md", "src/downloads/index.md"):
+        _write(root, relative, downloads)
+
+
 def test_happy_path_and_release_tag(tmp_path):
     root = _fixture(tmp_path)
     assert _module().main(["--root", str(root), "--release-tag", "v1.2.3"]) == 0
@@ -239,6 +290,101 @@ def test_happy_path_and_release_tag(tmp_path):
 def test_happy_path_without_release_tag(tmp_path):
     root = _fixture(tmp_path)
     assert _module().main(["--root", str(root)]) == 0
+
+
+def test_current_publication_requires_release_status(tmp_path):
+    root = _fixture(tmp_path)
+    config_path = root / "docs/book-config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    del config["publication"]["release_status"]
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    config_yml = root / "docs/_config.yml"
+    config_yml.write_text(
+        config_yml.read_text(encoding="utf-8").replace(
+            'release_status: "published"\n', ""
+        ),
+        encoding="utf-8",
+    )
+
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_immutable_legacy_release_source_without_status_remains_retryable(tmp_path):
+    root = _fixture(tmp_path)
+    config_path = root / "docs/book-config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    del config["publication"]["release_status"]
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    config_yml = root / "docs/_config.yml"
+    config_yml.write_text(
+        config_yml.read_text(encoding="utf-8").replace(
+            'release_status: "published"\n', ""
+        ),
+        encoding="utf-8",
+    )
+
+    assert _module().main(
+        ["--root", str(root), "--release-tag", "v1.2.3"]
+    ) == 0
+
+
+def test_published_status_rejects_stale_reader_copy(tmp_path):
+    root = _fixture(tmp_path)
+    readme = root / "README.md"
+    readme.write_text(
+        readme.read_text(encoding="utf-8") + " Release準備中",
+        encoding="utf-8",
+    )
+
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_preparing_status_requires_preparation_copy_and_rejects_current_release_links(
+    tmp_path,
+):
+    root = _fixture(tmp_path)
+    _set_release_status(root, "preparing")
+
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_preparing_status_with_synchronized_reader_copy_passes(tmp_path):
+    root = _fixture(tmp_path)
+    _set_release_status(root, "preparing")
+    _write_preparing_reader_copy(root)
+
+    assert _module().main(["--root", str(root)]) == 0
+
+
+def test_preparing_status_rejects_asset_links_outside_downloads(tmp_path):
+    root = _fixture(tmp_path)
+    _set_release_status(root, "preparing")
+    _write_preparing_reader_copy(root)
+    asset_base = (
+        "https://github.com/itdojp/theoretical-computer-science-textbook/"
+        "releases/download/v1.2.3/theoretical-computer-science-textbook-v1.2.3"
+    )
+    readme = root / "README.md"
+    readme.write_text(
+        readme.read_text(encoding="utf-8") + f" {asset_base}.pdf",
+        encoding="utf-8",
+    )
+    changelog = root / "docs/changelog/index.md"
+    changed = changelog.read_text(encoding="utf-8") + f" {asset_base}.epub"
+    changelog.write_text(changed, encoding="utf-8")
+    _write(root, "src/changelog/index.md", changed)
+
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_unknown_release_status_fails(tmp_path):
+    root = _fixture(tmp_path)
+    config_path = root / "docs/book-config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["publication"]["release_status"] = "available"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    assert _module().main(["--root", str(root)]) == 1
 
 
 def test_trusted_contract_root_does_not_execute_release_source_code(tmp_path):
@@ -345,6 +491,16 @@ def test_workflow_requires_slash_safe_artifact_label(tmp_path):
         "ARTIFACT_SOURCE//\\//-", "ARTIFACT_SOURCE"
     )
     workflow.write_text(text, encoding="utf-8")
+    assert _module().main(["--root", str(root)]) == 1
+
+
+def test_workflow_rejects_duplicate_step_name_shadowing(tmp_path):
+    root = _fixture(tmp_path)
+    workflow = root / ".github/workflows/release-artifacts.yml"
+    text = workflow.read_text(encoding="utf-8")
+    duplicate = "      - name: Resolve filesystem-safe artifact label\n        run: true\n"
+    workflow.write_text(text.replace("    steps:\n", f"    steps:\n{duplicate}", 1), encoding="utf-8")
+
     assert _module().main(["--root", str(root)]) == 1
 
 

--- a/python/tests/test_check_publication_metadata.py
+++ b/python/tests/test_check_publication_metadata.py
@@ -262,6 +262,29 @@ def _set_release_status(root: Path, status: str) -> None:
     )
 
 
+def _remove_release_status(root: Path) -> None:
+    config_path = root / "docs/book-config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    del config["publication"]["release_status"]
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    config_yml = root / "docs/_config.yml"
+    config_yml.write_text(
+        config_yml.read_text(encoding="utf-8").replace(
+            'release_status: "published"\n', ""
+        ),
+        encoding="utf-8",
+    )
+
+
+def _replace_fixture_version(root: Path, old: str, new: str) -> None:
+    for path in root.rglob("*"):
+        if path.is_file():
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(old, new),
+                encoding="utf-8",
+            )
+
+
 def _write_preparing_reader_copy(root: Path) -> None:
     _write(
         root,
@@ -294,38 +317,28 @@ def test_happy_path_without_release_tag(tmp_path):
 
 def test_current_publication_requires_release_status(tmp_path):
     root = _fixture(tmp_path)
-    config_path = root / "docs/book-config.json"
-    config = json.loads(config_path.read_text(encoding="utf-8"))
-    del config["publication"]["release_status"]
-    config_path.write_text(json.dumps(config), encoding="utf-8")
-    config_yml = root / "docs/_config.yml"
-    config_yml.write_text(
-        config_yml.read_text(encoding="utf-8").replace(
-            'release_status: "published"\n', ""
-        ),
-        encoding="utf-8",
-    )
+    _remove_release_status(root)
 
     assert _module().main(["--root", str(root)]) == 1
 
 
 def test_immutable_legacy_release_source_without_status_remains_retryable(tmp_path):
     root = _fixture(tmp_path)
-    config_path = root / "docs/book-config.json"
-    config = json.loads(config_path.read_text(encoding="utf-8"))
-    del config["publication"]["release_status"]
-    config_path.write_text(json.dumps(config), encoding="utf-8")
-    config_yml = root / "docs/_config.yml"
-    config_yml.write_text(
-        config_yml.read_text(encoding="utf-8").replace(
-            'release_status: "published"\n', ""
-        ),
-        encoding="utf-8",
-    )
+    _replace_fixture_version(root, "1.2.3", "1.2.0")
+    _remove_release_status(root)
+
+    assert _module().main(
+        ["--root", str(root), "--release-tag", "v1.2.0"]
+    ) == 0
+
+
+def test_nonlegacy_release_source_without_status_fails(tmp_path):
+    root = _fixture(tmp_path)
+    _remove_release_status(root)
 
     assert _module().main(
         ["--root", str(root), "--release-tag", "v1.2.3"]
-    ) == 0
+    ) == 1
 
 
 def test_published_status_rejects_stale_reader_copy(tmp_path):

--- a/scripts/check_publication_metadata.py
+++ b/scripts/check_publication_metadata.py
@@ -16,6 +16,11 @@ SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 CHAPTER_IDS = {str(number) for number in range(1, 13)}
 LEGACY_TITLE = "理論計算機科学教本 - コンピュータサイエンス基礎理論"
+RELEASE_BASE_URL = (
+    "https://github.com/itdojp/theoretical-computer-science-textbook/releases"
+)
+RELEASE_STATUSES = {"preparing", "published"}
+STALE_PUBLISHED_COPY = ("Release準備中", "Release完了後", "配布予定tag")
 
 
 def _read(path: Path, errors: list[str]) -> str:
@@ -83,6 +88,19 @@ def validate_config(root: Path, errors: list[str]) -> dict[str, Any] | None:
     release_tag = _required_string(
         publication.get("release_tag"), "publication.release_tag", errors
     )
+    release_status_value = publication.get("release_status")
+    release_status = (
+        None
+        if release_status_value is None
+        else _required_string(
+            release_status_value, "publication.release_status", errors
+        )
+    )
+    if release_status is not None and release_status not in RELEASE_STATUSES:
+        errors.append(
+            "publication.release_status: must be one of "
+            f"{sorted(RELEASE_STATUSES)!r}"
+        )
     parsed_release = _parse_date(release_date, "publication.release_date", errors)
     parsed_updated = _parse_date(last_updated, "publication.last_updated", errors)
     if parsed_release is not None and parsed_updated is not None and parsed_updated < parsed_release:
@@ -139,6 +157,21 @@ def _must_contain(path: Path, text: str, values: tuple[str, ...], errors: list[s
         errors.append(f"{path}: legacy title remains")
 
 
+def _must_not_contain(
+    path: Path, text: str, values: tuple[str, ...], errors: list[str]
+) -> None:
+    for value in values:
+        if value in text:
+            errors.append(f"{path}: stale value remains {value!r}")
+
+
+def _must_contain_any(
+    path: Path, text: str, values: tuple[str, ...], errors: list[str]
+) -> None:
+    if not any(value in text for value in values):
+        errors.append(f"{path}: missing one of canonical values {values!r}")
+
+
 def _check_mirror(root: Path, docs_relative: str, src_relative: str, errors: list[str]) -> None:
     docs_path, src_path = root / docs_relative, root / src_relative
     docs_text, src_text = _read(docs_path, errors), _read(src_path, errors)
@@ -155,23 +188,27 @@ def validate_consumers(root: Path, cfg: dict[str, Any], errors: list[str]) -> No
     release_date = publication.get("release_date")
     last_updated = publication.get("last_updated")
     release_tag = publication.get("release_tag")
+    release_status = publication.get("release_status")
     if not all(isinstance(value, str) for value in (release_date, last_updated, release_tag)):
         return
 
     config_path = root / "docs/_config.yml"
     config_text = _read(config_path, errors)
+    expected_config = {
+        "title": title,
+        "description": description,
+        "author": author,
+        "version": version,
+        "release_date": release_date,
+        "last_updated": last_updated,
+        "release_tag": release_tag,
+    }
+    if isinstance(release_status, str):
+        expected_config["release_status"] = release_status
     _check_yaml_values(
         config_path,
         config_text,
-        {
-            "title": title,
-            "description": description,
-            "author": author,
-            "version": version,
-            "release_date": release_date,
-            "last_updated": last_updated,
-            "release_tag": release_tag,
-        },
+        expected_config,
         errors,
     )
 
@@ -249,6 +286,24 @@ def validate_consumers(root: Path, cfg: dict[str, Any], errors: list[str]) -> No
         (version, release_date, release_tag, "PDF", "EPUB", "Web版", "GitHub Releases"),
         errors,
     )
+    release_url = f"{RELEASE_BASE_URL}/tag/{release_tag}"
+    asset_prefix = "theoretical-computer-science-textbook-"
+    pdf_url = f"{RELEASE_BASE_URL}/download/{release_tag}/{asset_prefix}{release_tag}.pdf"
+    epub_url = f"{RELEASE_BASE_URL}/download/{release_tag}/{asset_prefix}{release_tag}.epub"
+    reader_pages = (
+        (readme_path, readme),
+        (changelog_path, changelog),
+        (downloads_path, downloads),
+    )
+    if release_status == "published":
+        for path, text in reader_pages:
+            _must_contain(path, text, (release_url,), errors)
+            _must_not_contain(path, text, STALE_PUBLISHED_COPY, errors)
+        _must_contain(downloads_path, downloads, (pdf_url, epub_url), errors)
+    elif release_status == "preparing":
+        for path, text in reader_pages:
+            _must_contain_any(path, text, STALE_PUBLISHED_COPY, errors)
+            _must_not_contain(path, text, (release_url, pdf_url, epub_url), errors)
     _check_mirror(root, "docs/introduction/index.md", "src/introduction/index.md", errors)
     _check_mirror(root, "docs/afterword/index.md", "src/afterword/index.md", errors)
     _check_mirror(root, "docs/changelog/index.md", "src/changelog/index.md", errors)
@@ -288,6 +343,14 @@ def validate_workflow(root: Path, errors: list[str]) -> None:
             errors.append(f"{path}: workflow_dispatch is missing {name}")
 
     steps = re.findall(r"(?ms)^      - (.*?)(?=^      - |\Z)", active)
+    step_names = [
+        match.group(1)
+        for step in steps
+        if (match := re.match(r"name:\s*(.*?)\s*(?:\n|$)", step)) is not None
+    ]
+    for name in sorted(set(step_names)):
+        if step_names.count(name) > 1:
+            errors.append(f"{path}: duplicate step name {name!r}")
 
     def step_named(name: str) -> str:
         prefix = f"name: {name}"
@@ -546,6 +609,15 @@ def main(argv: list[str] | None = None) -> int:
     if cfg is not None:
         publication = cfg.get("publication")
         canonical_tag = publication.get("release_tag") if isinstance(publication, dict) else None
+        release_status = (
+            publication.get("release_status") if isinstance(publication, dict) else None
+        )
+        # Immutable release sources created before this field was introduced remain
+        # retryable. Current branch validation must always declare the reader state.
+        if release_status is None and args.release_tag is None:
+            errors.append(
+                "publication.release_status: required for current publication state"
+            )
         if args.release_tag is not None and args.release_tag != canonical_tag:
             errors.append(
                 f"--release-tag {args.release_tag!r} does not match canonical {canonical_tag!r}"

--- a/scripts/check_publication_metadata.py
+++ b/scripts/check_publication_metadata.py
@@ -21,6 +21,9 @@ RELEASE_BASE_URL = (
 )
 RELEASE_STATUSES = {"preparing", "published"}
 STALE_PUBLISHED_COPY = ("Release準備中", "Release完了後", "配布予定tag")
+# v1.2.0 was frozen before release_status was introduced. Keep only this
+# immutable source retryable; every later release source must declare its state.
+LEGACY_RELEASE_TAGS_WITHOUT_STATUS = {"v1.2.0"}
 
 
 def _read(path: Path, errors: list[str]) -> str:
@@ -612,9 +615,10 @@ def main(argv: list[str] | None = None) -> int:
         release_status = (
             publication.get("release_status") if isinstance(publication, dict) else None
         )
-        # Immutable release sources created before this field was introduced remain
-        # retryable. Current branch validation must always declare the reader state.
-        if release_status is None and args.release_tag is None:
+        # Only immutable sources known to predate this field remain retryable.
+        if release_status is None and (
+            args.release_tag not in LEGACY_RELEASE_TAGS_WITHOUT_STATUS
+        ):
             errors.append(
                 "publication.release_status: required for current publication state"
             )

--- a/src/changelog/index.md
+++ b/src/changelog/index.md
@@ -5,7 +5,7 @@ title: "更新履歴（CHANGELOG）"
 
 # 更新履歴（CHANGELOG）
 
-Web版はmainブランチから継続公開し、版番号を固定したPDF/EPUBは`v1.2.0` tagのRelease完了後に提供します。ここではコミット列挙ではなく、読者へ影響する変更を版ごとに整理します。
+Web版はmainブランチから継続公開し、版番号を固定したPDF/EPUBは[`v1.2.0` Release](https://github.com/itdojp/theoretical-computer-science-textbook/releases/tag/v1.2.0)で提供しています。ここではコミット列挙ではなく、読者へ影響する変更を版ごとに整理します。
 
 ## Unreleased
 
@@ -36,6 +36,7 @@ Web版はmainブランチから継続公開し、版番号を固定したPDF/EPU
 - モバイルsidebarの重なりと表示条件を修正し、全公開ページのnavigation coverageを検査するようにしました。
 - notation、生成索引、HTML、リンク、docs禁止物、依存監査、Jekyll buildをCIで継続検査し、品質ゲート自体の配線も検証するようにしました。
 - 書名、版、著者、更新日、Release tagをcanonical metadataへ統合し、公式PDF/EPUBを安全に公開するRelease契約を整備しました。
+- `v1.2.0`のPDF/EPUBを2026-07-16にGitHub Releaseで公開しました。
 
 ## 1.1.2
 

--- a/src/downloads/index.md
+++ b/src/downloads/index.md
@@ -5,7 +5,7 @@ title: "オフライン版（PDF/EPUB）"
 
 # オフライン版（PDF/EPUB）
 
-本書はWeb版を内容の正本とし、固定版をオフラインで読むためのPDF/EPUBをGitHub Releasesで提供します。`v1.2.0`はRelease準備中であり、完了まではWeb版を利用してください。
+本書はWeb版を内容の正本とし、固定版をオフラインで読むためのPDF/EPUBをGitHub Releasesで提供します。`v1.2.0`の公式成果物は公開済みです。
 
 ## クイックナビ {#downloads-quick-nav}
 
@@ -18,9 +18,11 @@ title: "オフライン版（PDF/EPUB）"
 ## 現在の提供状況 {#downloads-current}
 
 - **Web版**: 利用できます。訂正を含む最新版は公開サイトを正本としてください。
-- **公式 PDF / EPUB**: `v1.2.0` tagのRelease完了後に提供します。
-- **配布先**: [GitHub Releases](https://github.com/itdojp/theoretical-computer-science-textbook/releases)
-- **配布予定tag**: `v1.2.0`
+- **公式 PDF / EPUB**: `v1.2.0`を提供中です。
+- **配布先**: [`v1.2.0` Release](https://github.com/itdojp/theoretical-computer-science-textbook/releases/tag/v1.2.0)
+- **PDF**: [theoretical-computer-science-textbook-v1.2.0.pdf](https://github.com/itdojp/theoretical-computer-science-textbook/releases/download/v1.2.0/theoretical-computer-science-textbook-v1.2.0.pdf)
+- **EPUB**: [theoretical-computer-science-textbook-v1.2.0.epub](https://github.com/itdojp/theoretical-computer-science-textbook/releases/download/v1.2.0/theoretical-computer-science-textbook-v1.2.0.epub)
+- **Release tag**: `v1.2.0`
 
 ## 読者向けの案内 {#downloads-reader}
 
@@ -35,7 +37,7 @@ title: "オフライン版（PDF/EPUB）"
 | --- | --- |
 | Release tag | `v1.2.0` |
 | 公開日 | 2026-07-16 |
-| 公式成果物 | PDF / EPUB（Release準備中） |
+| 公式成果物 | PDF / EPUB（提供中） |
 | 内容の正本 | Web版 |
 | 署名 | 未提供 |
 
@@ -63,7 +65,7 @@ python3 scripts/build_offline_book.py --target pdf --out dist/book.pdf.md --asse
 pandoc dist/book.pdf.md -o dist/theoretical-computer-science-textbook.pdf --toc --resource-path=dist --pdf-engine=xelatex
 ```
 
-公式成果物は `.github/workflows/release-artifacts.yml` がtag push時に生成します。ローカル生成物は公式Release assetではありません。
+公式成果物は `.github/workflows/release-artifacts.yml` がtag push時、または既存tagを指定した承認済みmanual retry時に生成します。ローカル生成物は公式Release assetではありません。
 
 ## Release運用 {#downloads-future}
 


### PR DESCRIPTION
## 概要

Issue #393 のRelease phaseを完了するため、公開済み `v1.2.0` のPDF/EPUB導線をREADME、公開CHANGELOG、ダウンロード案内へ反映します。

## 変更内容

- canonical metadataへ `publication.release_status: published` を追加
- README / CHANGELOG / downloadsを公開済み表現へ統一
- `v1.2.0` Release、PDF、EPUBへの直接リンクを追加
- 検索データを再生成
- publication checkerで次を検証
  - `preparing` / `published` の状態値とreader copyの双方向整合
  - published時のRelease/asset URL必須化と準備中文言排除
  - preparing時の当該Release/asset URL排除と準備中文言必須化
  - immutableな旧tag sourceのmanual retry互換性
  - workflow step名重複による契約検査shadowingの拒否

## Release証跡

- Release: https://github.com/itdojp/theoretical-computer-science-textbook/releases/tag/v1.2.0
- publish run: https://github.com/itdojp/theoretical-computer-science-textbook/actions/runs/29465886976
- tag target: `580ae13f525b57e75c4e16dbc217a3fd60c211d0`（annotated tagは移動していません）
- PDF/EPUB: GitHub Release assetとして公開済み、両URLともHTTP 200確認済み

## 検証

- `python3 -m pytest -q python/tests/test_check_publication_metadata.py`（29 passed）
- `make test`（84 passed）
- `npm test`（npm audit 0 vulnerabilitiesを含む）
- `npm run spellcheck`（72 files / 0 issues）
- index / search-data / figure-guide generated checks
- notation / docs regression / navigation checks
- Jekyll build + HTML notation + htmltest
- immutable `v1.2.0` sourceを現行trusted checkerで再検査
- `git diff --check`
- 独立レビュー: Blocker / High / Medium 0件

Closes #393