### PR TITLE
deps: brace-expansion脆弱性を修正版へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -904,9 +904,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## 概要

- `package-lock.json`のtransitive `brace-expansion`を5.0.6から5.0.7へ更新
- GHSA-3jxr-9vmj-r5cp（`>=3.0.0 <5.0.7`）を解消
- 本文、workflow、formatter pin、direct dependencyは未変更

Closes #426

## 検証

- `npm ci --omit=optional`
- `npm ls brace-expansion --all` → 5.0.7のみ
- `npm audit --omit=optional` → 0 vulnerabilities
- `npm test`
- `make test` → 111 passed
- Jekyll production build
- `python3 scripts/html_notation_check.py --site-root _site`
- `npm run check:exercises:html`
- pinned `book-formatter@69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c` Unicode/textlint/links/layout/structure → error/warning 0
- `git diff --check`
