### PR TITLE
docs: 平面双対とmin-cut対応の成立条件を明記

### DIFF
--- a/cspell-words.txt
+++ b/cspell-words.txt
@@ -160,6 +160,7 @@ bisimulation
 cdcl
 ciphertext
 codomain
+cofacial
 coffman
 cofinite
 cryptosystem
@@ -234,6 +235,7 @@ Peled
 Pieter
 Pnueli
 Rajeev
+Reif
 Rivest
 Rosen
 Sedgewick

--- a/docs/appendices/c.md
+++ b/docs/appendices/c.md
@@ -1604,18 +1604,99 @@ rank(x):
 
 **解答種別**: 詳細解答
 
-**問題**: プラナーグラフの双対グラフの定義と、最短路と最小カットの双対性を説明せよ。
+**問題**: 固定された平面埋め込みを持つ連結な無向plane graphで、同一faceの境界上にある
+\\(s,t\\) のminimum cutをdual shortest pathとして求めるための条件、構成、証明を示せ。
 
-**解答**（概要）:
+**解答**:
 
-(a) 双対グラフ \\(G^{\\ast}\\)：
-- 平面埋め込みされた連結平面グラフ G の各面（face）を \\(G^{\\ast}\\) の頂点とする
-- G の各辺 e は、隣接する2面 f,g を分けるので、\\(G^{\\ast}\\) に辺 \\(e^{\\ast}\\)（f と g を結ぶ）を置く
-  - 境界に接する場合も含め、埋め込みに依存する点に注意
+#### 前提と構成
 
-(b) 双対性（代表例）：
-- 平面グラフにおける s-t カットは、双対では「s と t を分離する閉路」に対応する  
-- 辺重みを保って双対に移すと、**最小 s-t カット**が**双対グラフ上の最短路/最小閉路**に対応する（埋め込み上の対応付けが必要）
+\\(G=(V,E)\\) を連結な無向plane graphとし、その平面埋め込みを固定する。各辺
+\\(e\\) のcapacityは \\(c(e)\\ge 0\\) であり、異なる頂点 \\(s,t\\) は同一face \\(f_0\\) の
+境界上にあると仮定する。「planar graphである」だけではdualは一意に定まらないため、fixed embeddingは
+定理のデータの一部である。
+
+埋め込みに対するdual graph \\(G^{\\ast}\\) は、primalの各faceを1頂点とし、primal edge \\(e\\) が
+接する2つのfaceをdual edge \\(e^{\\ast}\\) で結んで得る。橋は同じfaceの両側に接するためdualでは
+self-loopとなり、primalまたはdualの平行辺も許す。
+
+\\(f_0\\) の内部に補助辺 \\(e_0=(s,t)\\) を交差なく描き、拡張したplane graphを \\(\\widehat{G}\\) とする。
+\\(e_0\\) は \\(f_0\\) を2つのface \\(f_L,f_R\\) に分ける。\\(\\widehat{G}\\) のdualから
+\\(e_0^{\\ast}\\) を削除したグラフを \\(H=\\widehat{G}^{\\ast}-e_0^{\\ast}\\) とし、元の各辺
+\\(e\\in E\\) に対応するdual edgeへ
+
+\\[
+w(e^{\\ast})=c(e)
+\\]
+
+を割り当てる。ここで証明する主張は一意に、
+
+\\[
+\\min_{s\\in S,\\ t\\notin S} c(\\delta_G(S))
+=\\operatorname{dist}_{H}(f_L,f_R)
+\\]
+
+という**minimum \\(s\\)-\\(t\\) cutと \\(f_L\\)-\\(f_R\\) shortest pathの対応**である。
+
+#### cutからdual pathへ
+
+非負capacityのminimum \\(s\\)-\\(t\\) cutのうち、包含関係について極小な辺集合 \\(C\\) を選ぶ。
+\\(C\\) はbondであり、\\(G-C\\) の \\(s\\) 側と \\(t\\) 側はそれぞれ連結である。
+拡張グラフ \\(\\widehat{G}\\) では \\(C\\cup\\{e_0\\}\\) がbondなので、plane graphの
+bond--cycle dualityにより、対応するdual edge集合
+\\(C^{\\ast}\\cup\\{e_0^{\\ast}\\}\\) は \\(\\widehat{G}^{\\ast}\\) のsimple cycleになる。
+このcycleから \\(e_0^{\\ast}\\) を除くと、\\(H\\) の \\(f_L\\)-\\(f_R\\) path \\(P\\) を得る。
+
+#### dual pathからcutへ
+
+逆に、非負weightなので \\(H\\) のshortest \\(f_L\\)-\\(f_R\\) path \\(P\\) はsimpleに選べる。
+\\(P\\cup\\{e_0^{\\ast}\\}\\) はdualのsimple cycleであり、Jordan curve theoremにより平面を
+2領域に分ける。補助辺 \\(e_0\\) がこのcycleと交差するため、\\(s\\) と \\(t\\) は異なる領域にある。
+したがって、\\(P\\) の各dual edgeに対応するprimal edge集合 \\(C_P\\) は \\(s\\)-\\(t\\) cutである。
+この2方向から、minimum cutとshortest pathの最適値は互いを上から抑え、等しくなる。
+
+#### 容量と重みの一致
+
+対応する辺ごとに \\(w(e^{\\ast})=c(e)\\) と定義したので、上の対応では
+
+\\[
+w(P)=\\sum_{e^{\\ast}\\in P}w(e^{\\ast})
+=\\sum_{e\\in C_P}c(e)=c(C_P)
+\\]
+
+が成り立つ。したがって、dual shortest pathの距離はprimal minimum cutのcapacityそのものである。
+
+#### 4-cycleでの手計算
+
+4-cycleを時計回りに \\(s-a-t-b-s\\) と埋め込み、
+\\(c(sa),c(at),c(tb),c(bs))=(2,3,1,4)\\) とする。\\(e_0=(s,t)\\) を外側のfaceへ追加すると、
+dualでは \\(f_L\\) から内側のface \\(f_I\\) まで重み2と3の平行辺、\\(f_I\\) から
+\\(f_R\\) まで重み1と4の平行辺を得る。よってshortest pathの重みは
+
+\\[
+\\min(2,3)+\\min(1,4)=2+1=3
+\\]
+
+である。primal側の4つの候補cutは、\\(S=\\{s\\},\\{s,a\\},\\{s,b\\},\\{s,a,b\\}\\) の順に
+capacity \\(6,7,3,4\\) を持つ。したがって \\(\\delta(\\{s,b\\})=\\{sa,bt\\}\\) がcapacity 3の
+minimum cutであり、dual pathが選ぶ重み2の \\(sa\\) と重み1の \\(bt\\) に辺ごとに対応する。
+
+#### 成立範囲
+
+ここでshortest pathと言えるのは、\\(s,t\\) が同一faceの境界上にあり、補助辺
+\\(e_0\\) によって分かれた**固定された2つのdual face \\(f_L,f_R\\)**を端点にできるからである。
+この前提を外した一般のplane graphでは、cut側の表現は \\(s,t\\) を分離するminimum separating cycleであり、
+単一の既知face対に対するshortest pathと無条件に同一視してはならない。本問はcofacialな無向の場合だけを扱い、
+directed planar flow、一般のminimum separating cycleアルゴリズム、higher-genus surfaceへの一般化は対象外とする。
+
+#### 出典と拡張の境界
+
+この補助辺によるcost-preservingなcut--path対応は、Reif (1983) Section 3, Theorem 2の
+\\((s,t)\\)-planar networkに対する定式化に基づく（[原論文PDF](https://users.cs.duke.edu/~reif/paper/stcut.pdf)、
+DOI: 10.1137/0212005）。
+同論文の定理は正のcostを仮定する。本解答で用いた非負capacityへの拡張は、0-weight edgeがあっても
+minimum cutから包含極小なものを、shortest walkからsimple pathを選べることによる。これは本文で明示した
+bond--cycleの議論から従う拡張であり、一次文献の定理文をそのまま引用した主張ではない。
 
 <span id="ex-sol-ch8-006"></span>
 ### 練習問題8.6（発展6）

--- a/docs/assets/search-data.json
+++ b/docs/assets/search-data.json
@@ -1034,7 +1034,7 @@
       "url": "/theoretical-computer-science-textbook/chapter-8/#exq-ch8-004"
     },
     {
-      "excerpt": "プラナーグラフの双対グラフについて：",
+      "excerpt": "次の条件を固定する。\\ G= V,E \\ は 連結な無向plane graph",
       "source_path": "docs/chapter-8/index.md",
       "title": "第8章 問題5（発展問題）",
       "url": "/theoretical-computer-science-textbook/chapter-8/#exq-ch8-005"

--- a/docs/chapter-8/index.md
+++ b/docs/chapter-8/index.md
@@ -594,6 +594,7 @@ Gale-Shapley(男性の選好, 女性の選好):
 - **標準**: Adrian Bondy, U. S. R. Murty, 『Graph Theory』. グラフ理論の基本概念から定理までを整理して復習できます。
 - **ネットワーク**: Ravindra K. Ahuja, Thomas L. Magnanti, James B. Orlin, 『Network Flows』. 最短路・最大流・最小費用流を体系的に深掘りしたい読者向けです。
 - **アルゴリズム**: Jon Kleinberg, Éva Tardos, 『Algorithm Design』. グラフ問題の設計判断と実用上の典型例を追いやすい標準書です。
+- **平面双対**: John H. Reif, “Minimum s-t Cut of a Planar Undirected Network in O(n log^2 n) Time,” *SIAM Journal on Computing* 12(1), 1983, Sections 2.4 and 3（[原論文PDF](https://users.cs.duke.edu/~reif/paper/stcut.pdf)、DOI: 10.1137/0212005）. 同一face上の端点に対する補助辺とdual shortest pathの対応を確認できます。
 - **出典メモ**: 最短路では Dijkstra、フローでは Ford–Fulkerson 系の古典的結果が核になります。本章ではそれらを現代的な計算量評価と実装上の前提条件に接続しています。
 - **次の一歩**: グラフ上の性質を論理で記述して検証したい場合は第9章へ進んでください。分散ネットワークや状態遷移系の応用像を見たい場合は第12章と往復すると見通しが良くなります。
 ## 章末問題
@@ -634,9 +635,17 @@ Gale-Shapley(男性の選好, 女性の選好):
 
 ### 発展問題
 
-5. <span id="exq-ch8-005"></span>プラナーグラフの双対グラフについて：
-   (a) 双対グラフの定義と性質を述べよ
-   (b) 最短路と最小カットの双対性を説明せよ
+5. <span id="exq-ch8-005"></span>次の条件を固定する。\(G=(V,E)\) は**連結な無向plane graph**
+   （固定された平面埋め込みを持つグラフ）、各辺 \(e\) のedge capacity \(c(e)\) は非負であり、
+   異なる頂点 \(s,t\) は同一faceの境界上にある。
+   (a) 埋め込みに対するdual graph \(G^{\ast}\) を定義し、橋と平行辺が双対でどう表されるか述べよ。
+   (b) \(s,t\) が接するface内に補助辺 \(e_0=(s,t)\) を交差なく追加する。この辺が元のfaceを
+   \(f_L,f_R\) に分けるとする。拡張後のdual graphから \(e_0^{\ast}\) を削除し、元の各辺に対して
+   \(w(e^{\ast})=c(e)\) と置いたとき、minimum \(s\)-\(t\) cutの容量が \(f_L\)-\(f_R\)
+   shortest pathの重みに等しいことを、両方向の対応を示して証明せよ。この設問ではshortest path版だけを証明し、
+   一般の埋め込みで現れるminimum separating cycleとは区別すること。
+   (c) 4-cycle \(s-a-t-b-s\) を固定埋め込みし、容量を順に \(2,3,1,4\) とした例で、
+   primal cutとdual pathの値を手計算せよ。
 
 - **詳細解答**: [付録Cの対応解答](../appendices/c/#ex-sol-ch8-005)
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -6254,7 +6254,7 @@
       "url": "/theoretical-computer-science-textbook/chapter-8/#exq-ch8-004"
     },
     {
-      "excerpt": "プラナーグラフの双対グラフについて：",
+      "excerpt": "次の条件を固定する。\\(G=(V,E)\\) は連結な無向plane graph",
       "id": "exq-ch8-005",
       "kind": "exercise",
       "label": "章末問題",

--- a/python/tests/test_check_appendix_c_consistency.py
+++ b/python/tests/test_check_appendix_c_consistency.py
@@ -15,6 +15,9 @@ from check_appendix_c_consistency import (  # noqa: E402
     BAKERY_SOLUTION_REQUIREMENTS,
     LEGACY_APPENDIX_ALIASES,
     LEGACY_CHAPTER_ALIASES,
+    PLANAR_DUAL_FORBIDDEN_SNIPPETS,
+    PLANAR_DUAL_QUESTION_REQUIREMENTS,
+    PLANAR_DUAL_SOLUTION_REQUIREMENTS,
     check_repository,
     collect_appendix_solutions,
     validate_bakery_solution_contract,
@@ -22,8 +25,10 @@ from check_appendix_c_consistency import (  # noqa: E402
     validate_cross_references,
     validate_html,
     validate_index,
+    validate_planar_dual_exercise_contract,
+    validate_planar_dual_four_cycle_example,
 )
-from exercise_references import ExerciseQuestion  # noqa: E402
+from exercise_references import ExerciseQuestion, collect_chapter_questions  # noqa: E402
 
 
 def _question(
@@ -84,6 +89,26 @@ def _write_repository_fixture(root: Path) -> tuple[Path, Path, Path, Path, Path,
             f'<span id="{alias}"></span>'
             for alias in LEGACY_CHAPTER_ALIASES.get(chapter, ())
         )
+        if chapter == 8:
+            for number in range(2, 5):
+                chapter_text += f"""
+
+{number}. <span id="exq-ch8-{number:03d}"></span>第8章のfixture問題{number}
+
+- **詳細解答**: [付録Cの対応解答](../appendices/c/#ex-sol-ch8-{number:03d})
+"""
+            question_contract = "\n".join(
+                snippet
+                for snippets in PLANAR_DUAL_QUESTION_REQUIREMENTS.values()
+                for snippet in snippets
+            )
+            chapter_text += f"""
+
+5. <span id="exq-ch8-005"></span>平面双対の契約fixture
+{question_contract}
+
+- **詳細解答**: [付録Cの対応解答](../appendices/c/#ex-sol-ch8-005)
+"""
         for source_root in (docs_root, src_root):
             path = source_root / f"chapter-{chapter}" / "index.md"
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -104,6 +129,39 @@ def _write_repository_fixture(root: Path) -> tuple[Path, Path, Path, Path, Path,
 解答本文。
 """
         )
+        if chapter == 8:
+            for number in range(2, 5):
+                appendix_parts[-1] += f"""
+
+<span id="ex-sol-ch8-{number:03d}"></span>
+### 練習問題8.{number}
+
+**問題**: 第8章のfixture問題{number}
+
+**元問題**: [第8章 問題{number}]({{{{ '/chapter-8/' | relative_url }}}}#exq-ch8-{number:03d})
+
+**解答種別**: 詳細解答
+
+解答本文。
+"""
+            solution_contract = "\n".join(
+                snippet
+                for snippets in PLANAR_DUAL_SOLUTION_REQUIREMENTS.values()
+                for snippet in snippets
+            )
+            appendix_parts[-1] += f"""
+
+<span id="ex-sol-ch8-005"></span>
+### 練習問題8.5
+
+**問題**: 平面双対の契約fixture
+
+**元問題**: [第8章 問題5]({{{{ '/chapter-8/' | relative_url }}}}#exq-ch8-005)
+
+**解答種別**: 詳細解答
+
+{solution_contract}
+"""
         index_items.append(
             {
                 "id": question_id,
@@ -111,6 +169,25 @@ def _write_repository_fixture(root: Path) -> tuple[Path, Path, Path, Path, Path,
                 "url": f"/theoretical-computer-science-textbook/chapter-{chapter}/#{question_id}",
             }
         )
+        if chapter == 8:
+            for number in range(2, 5):
+                index_items.append(
+                    {
+                        "id": f"exq-ch8-{number:03d}",
+                        "kind": "exercise",
+                        "url": (
+                            "/theoretical-computer-science-textbook/chapter-8/"
+                            f"#exq-ch8-{number:03d}"
+                        ),
+                    }
+                )
+            index_items.append(
+                {
+                    "id": "exq-ch8-005",
+                    "kind": "exercise",
+                    "url": "/theoretical-computer-science-textbook/chapter-8/#exq-ch8-005",
+                }
+            )
 
         html = site_root / f"chapter-{chapter}" / "index.html"
         html.parent.mkdir(parents=True, exist_ok=True)
@@ -119,6 +196,12 @@ def _write_repository_fixture(root: Path) -> tuple[Path, Path, Path, Path, Path,
             f'<span id="{alias}"></span>'
             for alias in LEGACY_CHAPTER_ALIASES.get(chapter, ())
         )
+        if chapter == 8:
+            chapter_html.extend(
+                f'<p id="exq-ch8-{number:03d}">問題</p>'
+                for number in range(2, 5)
+            )
+            chapter_html.append('<p id="exq-ch8-005">問題</p>')
         html.write_text("\n".join(chapter_html), encoding="utf-8")
 
     appendix_text = "\n".join(appendix_parts) + "\n" + "\n".join(
@@ -139,6 +222,8 @@ def _write_repository_fixture(root: Path) -> tuple[Path, Path, Path, Path, Path,
         "\n".join(
             [
                 *(f'<span id="ex-sol-ch{chapter}-001"></span>' for chapter in range(1, 13)),
+                *(f'<span id="ex-sol-ch8-{number:03d}"></span>' for number in range(2, 5)),
+                '<span id="ex-sol-ch8-005"></span>',
                 *(f'<span id="{alias}"></span>' for alias in sorted(LEGACY_APPENDIX_ALIASES)),
             ]
         ),
@@ -260,6 +345,122 @@ def test_bakery_solution_contract_rejects_each_missing_obligation(
 
 def test_two_process_bakery_model_covers_races_without_mutual_exclusion_violation() -> None:
     assert validate_bakery_two_process_interleavings() == []
+
+
+def _planar_dual_question(block: str) -> ExerciseQuestion:
+    return ExerciseQuestion(
+        8,
+        5,
+        "発展問題",
+        "exq-ch8-005",
+        "平面双対",
+        block,
+        200,
+        "list",
+    )
+
+
+def _planar_dual_solution(block: str) -> AppendixSolution:
+    return AppendixSolution(
+        8,
+        5,
+        "ex-sol-ch8-005",
+        "exq-ch8-005",
+        "第8章 問題5（発展）",
+        "",
+        "詳細解答",
+        block,
+        300,
+    )
+
+
+def _production_planar_dual_rows() -> tuple[ExerciseQuestion, AppendixSolution]:
+    questions, question_errors = collect_chapter_questions(
+        (ROOT / "docs" / "chapter-8" / "index.md").read_text(encoding="utf-8"),
+        8,
+    )
+    solutions, solution_errors = collect_appendix_solutions(
+        (ROOT / "docs" / "appendices" / "c.md").read_text(encoding="utf-8")
+    )
+    assert question_errors == []
+    assert solution_errors == []
+    question = next(
+        row for row in questions if (row.chapter, row.display_number) == (8, 5)
+    )
+    solution = next(row for row in solutions if (row.chapter, row.number) == (8, 5))
+    return question, solution
+
+
+def test_planar_dual_contract_accepts_production_exercise() -> None:
+    question, solution = _production_planar_dual_rows()
+
+    assert validate_planar_dual_exercise_contract([question], [solution]) == []
+
+
+def test_planar_dual_contract_requires_question_and_solution_presence() -> None:
+    errors = validate_planar_dual_exercise_contract([], [])
+
+    assert any("lacks its chapter question" in error for error in errors)
+    assert any("lacks its Appendix C solution" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("requirement", "snippet"),
+    [
+        (requirement, snippet)
+        for requirement, snippets in PLANAR_DUAL_QUESTION_REQUIREMENTS.items()
+        for snippet in snippets
+    ],
+)
+def test_planar_dual_question_contract_rejects_each_missing_obligation(
+    requirement: str, snippet: str
+) -> None:
+    question, solution = _production_planar_dual_rows()
+    assert snippet in question.block
+    weakened = question.block.replace(snippet, "")
+
+    errors = validate_planar_dual_exercise_contract(
+        [_planar_dual_question(weakened)], [solution]
+    )
+
+    assert any(f"requirement {requirement!r}" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("requirement", "snippet"),
+    [
+        (requirement, snippet)
+        for requirement, snippets in PLANAR_DUAL_SOLUTION_REQUIREMENTS.items()
+        for snippet in snippets
+    ],
+)
+def test_planar_dual_solution_contract_rejects_each_missing_obligation(
+    requirement: str, snippet: str
+) -> None:
+    question, solution = _production_planar_dual_rows()
+    assert snippet in solution.block
+    weakened = solution.block.replace(snippet, "")
+
+    errors = validate_planar_dual_exercise_contract(
+        [question], [_planar_dual_solution(weakened)]
+    )
+
+    assert any(f"requirement {requirement!r}" in error for error in errors)
+
+
+@pytest.mark.parametrize("forbidden", PLANAR_DUAL_FORBIDDEN_SNIPPETS)
+def test_planar_dual_contract_rejects_ambiguous_or_overbroad_wording(forbidden: str) -> None:
+    question, solution = _production_planar_dual_rows()
+
+    errors = validate_planar_dual_exercise_contract(
+        [_planar_dual_question(question.block + "\n" + forbidden)], [solution]
+    )
+
+    assert any(repr(forbidden) in error for error in errors)
+
+
+def test_planar_dual_four_cycle_example_matches_primal_and_dual_values() -> None:
+    assert validate_planar_dual_four_cycle_example() == []
 
 
 def test_reciprocal_type_must_be_on_the_link_to_that_solution() -> None:

--- a/python/tests/test_check_appendix_c_consistency.py
+++ b/python/tests/test_check_appendix_c_consistency.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -385,9 +386,9 @@ def _production_planar_dual_rows() -> tuple[ExerciseQuestion, AppendixSolution]:
     assert question_errors == []
     assert solution_errors == []
     question = next(
-        row for row in questions if (row.chapter, row.display_number) == (8, 5)
+        row for row in questions if row.stable_id == "exq-ch8-005"
     )
-    solution = next(row for row in solutions if (row.chapter, row.number) == (8, 5))
+    solution = next(row for row in solutions if row.stable_id == "ex-sol-ch8-005")
     return question, solution
 
 
@@ -402,6 +403,15 @@ def test_planar_dual_contract_requires_question_and_solution_presence() -> None:
 
     assert any("lacks its chapter question" in error for error in errors)
     assert any("lacks its Appendix C solution" in error for error in errors)
+
+
+def test_planar_dual_contract_follows_stable_ids_after_visible_renumbering() -> None:
+    question, solution = _production_planar_dual_rows()
+
+    assert validate_planar_dual_exercise_contract(
+        [replace(question, display_number=99)],
+        [replace(solution, number=99)],
+    ) == []
 
 
 @pytest.mark.parametrize(

--- a/scripts/check_appendix_c_consistency.py
+++ b/scripts/check_appendix_c_consistency.py
@@ -102,6 +102,116 @@ BAKERY_SOLUTION_REQUIREMENTS: dict[str, tuple[str, ...]] = {
     ),
 }
 
+PLANAR_DUAL_QUESTION_REQUIREMENTS: dict[str, tuple[str, ...]] = {
+    "fixed undirected plane model": (
+        "連結な無向plane graph",
+        "固定された平面埋め込み",
+        "edge capacity \\(c(e)\\) は非負",
+        "同一faceの境界上",
+    ),
+    "auxiliary-edge construction": (
+        "補助辺 \\(e_0=(s,t)\\)",
+        "\\(f_L,f_R\\)",
+        "\\(e_0^{\\ast}\\) を削除",
+    ),
+    "unique path theorem": (
+        "\\(w(e^{\\ast})=c(e)\\)",
+        "minimum \\(s\\)-\\(t\\) cut",
+        "\\(f_L\\)-\\(f_R\\)",
+        "shortest path版だけを証明",
+        "minimum separating cycleとは区別",
+    ),
+    "worked example": (
+        "4-cycle \\(s-a-t-b-s\\)",
+        "容量を順に \\(2,3,1,4\\)",
+        "primal cutとdual pathの値を手計算",
+    ),
+}
+
+PLANAR_DUAL_SOLUTION_REQUIREMENTS: dict[str, tuple[str, ...]] = {
+    "proof structure": (
+        "#### 前提と構成",
+        "#### cutからdual pathへ",
+        "#### dual pathからcutへ",
+        "#### 容量と重みの一致",
+        "#### 4-cycleでの手計算",
+        "#### 成立範囲",
+    ),
+    "fixed undirected plane model": (
+        "連結な無向plane graph",
+        "平面埋め込みを固定",
+        "\\(c(e)\\ge 0\\)",
+        "同一face \\(f_0\\) の",
+        "fixed embedding",
+    ),
+    "dual definition": (
+        "primalの各faceを1頂点",
+        "橋は同じfaceの両側に接する",
+        "self-loop",
+        "平行辺も許す",
+    ),
+    "auxiliary-edge construction": (
+        "補助辺 \\(e_0=(s,t)\\)",
+        "\\(f_L,f_R\\)",
+        "\\(H=\\widehat{G}^{\\ast}-e_0^{\\ast}\\)",
+        "\\(w(e^{\\ast})=c(e)\\)",
+    ),
+    "cut-to-path proof": (
+        "包含関係について極小",
+        "\\(C\\) はbond",
+        "bond--cycle duality",
+        "\\(C^{\\ast}\\cup\\{e_0^{\\ast}\\}\\)",
+        "\\(f_L\\)-\\(f_R\\) path",
+    ),
+    "path-to-cut proof": (
+        "shortest \\(f_L\\)-\\(f_R\\) path",
+        "simpleに選べる",
+        "Jordan curve theorem",
+        "\\(s\\) と \\(t\\) は異なる領域",
+        "\\(s\\)-\\(t\\) cut",
+    ),
+    "capacity preservation": (
+        "w(P)=\\sum_{e^{\\ast}\\in P}w(e^{\\ast})",
+        "=\\sum_{e\\in C_P}c(e)=c(C_P)",
+        "最適値は互いを上から抑え",
+    ),
+    "worked example": (
+        "\\(c(sa),c(at),c(tb),c(bs))=(2,3,1,4)\\)",
+        "\\min(2,3)+\\min(1,4)=2+1=3",
+        "capacity \\(6,7,3,4\\)",
+        "\\(\\delta(\\{s,b\\})=\\{sa,bt\\}\\)",
+        "capacity 3",
+    ),
+    "scope boundary": (
+        "固定された2つのdual face",
+        "minimum separating cycle",
+        "単一の既知face対に対するshortest pathと無条件に同一視してはならない",
+        "cofacialな無向の場合だけ",
+        "higher-genus surface",
+    ),
+    "primary source and extension boundary": (
+        "Reif (1983) Section 3, Theorem 2",
+        "https://users.cs.duke.edu/~reif/paper/stcut.pdf",
+        "正のcost",
+        "非負capacityへの拡張",
+    ),
+}
+
+# Appendix C writes TeX delimiters and commands with two literal backslashes,
+# unlike chapter questions, which use one.  Normalize the contract snippets to
+# the canonical Appendix C source representation without weakening exact-match
+# checks.
+PLANAR_DUAL_SOLUTION_REQUIREMENTS = {
+    requirement: tuple(snippet.replace("\\", "\\\\") for snippet in snippets)
+    for requirement, snippets in PLANAR_DUAL_SOLUTION_REQUIREMENTS.items()
+}
+
+PLANAR_DUAL_FORBIDDEN_SNIPPETS = (
+    "最短路/最小閉路",
+    "shortest path/minimum cycle",
+    "任意のplanar graphで",
+)
+
 LEGACY_CHAPTER_ALIASES: dict[int, tuple[str, ...]] = {
     1: (
         "1-集合演算を実装せよ",
@@ -465,6 +575,87 @@ def validate_bakery_solution_contract(solutions: list[AppendixSolution]) -> list
     return errors
 
 
+def validate_planar_dual_exercise_contract(
+    questions: list[ExerciseQuestion], solutions: list[AppendixSolution]
+) -> list[str]:
+    """Guard Exercise 8.5's fixed-embedding shortest-path theorem contract."""
+    matching_questions = [
+        question
+        for question in questions
+        if (question.chapter, question.display_number) == (8, 5)
+    ]
+    matching_solutions = [
+        solution for solution in solutions if (solution.chapter, solution.number) == (8, 5)
+    ]
+    errors: list[str] = []
+    if not matching_questions:
+        errors.append("練習問題8.5 planar-dual contract lacks its chapter question")
+    if not matching_solutions:
+        errors.append("練習問題8.5 planar-dual contract lacks its Appendix C solution")
+
+    for label, rows, requirements in (
+        ("question", matching_questions, PLANAR_DUAL_QUESTION_REQUIREMENTS),
+        ("solution", matching_solutions, PLANAR_DUAL_SOLUTION_REQUIREMENTS),
+    ):
+        if not rows:
+            continue
+        row = rows[0]
+        for requirement, snippets in requirements.items():
+            missing = [snippet for snippet in snippets if snippet not in row.block]
+            if missing:
+                errors.append(
+                    f"line {row.line}: 練習問題8.5 planar-dual {label} contract is missing "
+                    f"requirement {requirement!r}: {missing}"
+                )
+        for snippet in PLANAR_DUAL_FORBIDDEN_SNIPPETS:
+            if snippet in row.block:
+                errors.append(
+                    f"line {row.line}: 練習問題8.5 planar-dual {label} contract contains "
+                    f"ambiguous or overbroad wording {snippet!r}"
+                )
+    return errors
+
+
+def validate_planar_dual_four_cycle_example() -> list[str]:
+    """Check the concrete primal-cut and dual-path values used in Exercise 8.5."""
+    vertices = ("s", "a", "t", "b")
+    capacities = {
+        frozenset(("s", "a")): 2,
+        frozenset(("a", "t")): 3,
+        frozenset(("t", "b")): 1,
+        frozenset(("b", "s")): 4,
+    }
+    cut_values: list[int] = []
+    for mask in range(1 << len(vertices)):
+        side = {vertices[index] for index in range(len(vertices)) if mask & (1 << index)}
+        if "s" not in side or "t" in side:
+            continue
+        cut_values.append(
+            sum(
+                capacity
+                for endpoints, capacity in capacities.items()
+                if len(endpoints & side) == 1
+            )
+        )
+
+    primal_minimum = min(cut_values)
+    dual_shortest_path = min(2, 3) + min(1, 4)
+    errors: list[str] = []
+    if sorted(cut_values) != [3, 4, 6, 7]:
+        errors.append(f"planar-dual 4-cycle cut values changed: {sorted(cut_values)}")
+    if primal_minimum != 3:
+        errors.append(f"planar-dual 4-cycle primal minimum must be 3, got {primal_minimum}")
+    if dual_shortest_path != 3:
+        errors.append(
+            f"planar-dual 4-cycle dual shortest path must be 3, got {dual_shortest_path}"
+        )
+    if primal_minimum != dual_shortest_path:
+        errors.append(
+            "planar-dual 4-cycle primal minimum and dual shortest path must agree"
+        )
+    return errors
+
+
 def _advance_bakery_process(state: BakeryModelState, pid: int) -> BakeryModelState | None:
     """Advance one atomic SC action; return None while a process is waiting or done."""
     other = 1 - pid
@@ -646,6 +837,8 @@ def check_repository(
     errors.extend(validate_cross_references(questions, solutions))
     errors.extend(validate_bakery_solution_contract(solutions))
     errors.extend(validate_bakery_two_process_interleavings())
+    errors.extend(validate_planar_dual_exercise_contract(questions, solutions))
+    errors.extend(validate_planar_dual_four_cycle_example())
     errors.extend(validate_index(index_path, questions))
     if site_root is not None:
         errors.extend(validate_html(site_root, questions, solutions))

--- a/scripts/check_appendix_c_consistency.py
+++ b/scripts/check_appendix_c_consistency.py
@@ -582,10 +582,10 @@ def validate_planar_dual_exercise_contract(
     matching_questions = [
         question
         for question in questions
-        if (question.chapter, question.display_number) == (8, 5)
+        if question.stable_id == "exq-ch8-005"
     ]
     matching_solutions = [
-        solution for solution in solutions if (solution.chapter, solution.number) == (8, 5)
+        solution for solution in solutions if solution.stable_id == "ex-sol-ch8-005"
     ]
     errors: list[str] = []
     if not matching_questions:

--- a/src/appendices/c.md
+++ b/src/appendices/c.md
@@ -1604,18 +1604,99 @@ rank(x):
 
 **解答種別**: 詳細解答
 
-**問題**: プラナーグラフの双対グラフの定義と、最短路と最小カットの双対性を説明せよ。
+**問題**: 固定された平面埋め込みを持つ連結な無向plane graphで、同一faceの境界上にある
+\\(s,t\\) のminimum cutをdual shortest pathとして求めるための条件、構成、証明を示せ。
 
-**解答**（概要）:
+**解答**:
 
-(a) 双対グラフ \\(G^{\\ast}\\)：
-- 平面埋め込みされた連結平面グラフ G の各面（face）を \\(G^{\\ast}\\) の頂点とする
-- G の各辺 e は、隣接する2面 f,g を分けるので、\\(G^{\\ast}\\) に辺 \\(e^{\\ast}\\)（f と g を結ぶ）を置く
-  - 境界に接する場合も含め、埋め込みに依存する点に注意
+#### 前提と構成
 
-(b) 双対性（代表例）：
-- 平面グラフにおける s-t カットは、双対では「s と t を分離する閉路」に対応する  
-- 辺重みを保って双対に移すと、**最小 s-t カット**が**双対グラフ上の最短路/最小閉路**に対応する（埋め込み上の対応付けが必要）
+\\(G=(V,E)\\) を連結な無向plane graphとし、その平面埋め込みを固定する。各辺
+\\(e\\) のcapacityは \\(c(e)\\ge 0\\) であり、異なる頂点 \\(s,t\\) は同一face \\(f_0\\) の
+境界上にあると仮定する。「planar graphである」だけではdualは一意に定まらないため、fixed embeddingは
+定理のデータの一部である。
+
+埋め込みに対するdual graph \\(G^{\\ast}\\) は、primalの各faceを1頂点とし、primal edge \\(e\\) が
+接する2つのfaceをdual edge \\(e^{\\ast}\\) で結んで得る。橋は同じfaceの両側に接するためdualでは
+self-loopとなり、primalまたはdualの平行辺も許す。
+
+\\(f_0\\) の内部に補助辺 \\(e_0=(s,t)\\) を交差なく描き、拡張したplane graphを \\(\\widehat{G}\\) とする。
+\\(e_0\\) は \\(f_0\\) を2つのface \\(f_L,f_R\\) に分ける。\\(\\widehat{G}\\) のdualから
+\\(e_0^{\\ast}\\) を削除したグラフを \\(H=\\widehat{G}^{\\ast}-e_0^{\\ast}\\) とし、元の各辺
+\\(e\\in E\\) に対応するdual edgeへ
+
+\\[
+w(e^{\\ast})=c(e)
+\\]
+
+を割り当てる。ここで証明する主張は一意に、
+
+\\[
+\\min_{s\\in S,\\ t\\notin S} c(\\delta_G(S))
+=\\operatorname{dist}_{H}(f_L,f_R)
+\\]
+
+という**minimum \\(s\\)-\\(t\\) cutと \\(f_L\\)-\\(f_R\\) shortest pathの対応**である。
+
+#### cutからdual pathへ
+
+非負capacityのminimum \\(s\\)-\\(t\\) cutのうち、包含関係について極小な辺集合 \\(C\\) を選ぶ。
+\\(C\\) はbondであり、\\(G-C\\) の \\(s\\) 側と \\(t\\) 側はそれぞれ連結である。
+拡張グラフ \\(\\widehat{G}\\) では \\(C\\cup\\{e_0\\}\\) がbondなので、plane graphの
+bond--cycle dualityにより、対応するdual edge集合
+\\(C^{\\ast}\\cup\\{e_0^{\\ast}\\}\\) は \\(\\widehat{G}^{\\ast}\\) のsimple cycleになる。
+このcycleから \\(e_0^{\\ast}\\) を除くと、\\(H\\) の \\(f_L\\)-\\(f_R\\) path \\(P\\) を得る。
+
+#### dual pathからcutへ
+
+逆に、非負weightなので \\(H\\) のshortest \\(f_L\\)-\\(f_R\\) path \\(P\\) はsimpleに選べる。
+\\(P\\cup\\{e_0^{\\ast}\\}\\) はdualのsimple cycleであり、Jordan curve theoremにより平面を
+2領域に分ける。補助辺 \\(e_0\\) がこのcycleと交差するため、\\(s\\) と \\(t\\) は異なる領域にある。
+したがって、\\(P\\) の各dual edgeに対応するprimal edge集合 \\(C_P\\) は \\(s\\)-\\(t\\) cutである。
+この2方向から、minimum cutとshortest pathの最適値は互いを上から抑え、等しくなる。
+
+#### 容量と重みの一致
+
+対応する辺ごとに \\(w(e^{\\ast})=c(e)\\) と定義したので、上の対応では
+
+\\[
+w(P)=\\sum_{e^{\\ast}\\in P}w(e^{\\ast})
+=\\sum_{e\\in C_P}c(e)=c(C_P)
+\\]
+
+が成り立つ。したがって、dual shortest pathの距離はprimal minimum cutのcapacityそのものである。
+
+#### 4-cycleでの手計算
+
+4-cycleを時計回りに \\(s-a-t-b-s\\) と埋め込み、
+\\(c(sa),c(at),c(tb),c(bs))=(2,3,1,4)\\) とする。\\(e_0=(s,t)\\) を外側のfaceへ追加すると、
+dualでは \\(f_L\\) から内側のface \\(f_I\\) まで重み2と3の平行辺、\\(f_I\\) から
+\\(f_R\\) まで重み1と4の平行辺を得る。よってshortest pathの重みは
+
+\\[
+\\min(2,3)+\\min(1,4)=2+1=3
+\\]
+
+である。primal側の4つの候補cutは、\\(S=\\{s\\},\\{s,a\\},\\{s,b\\},\\{s,a,b\\}\\) の順に
+capacity \\(6,7,3,4\\) を持つ。したがって \\(\\delta(\\{s,b\\})=\\{sa,bt\\}\\) がcapacity 3の
+minimum cutであり、dual pathが選ぶ重み2の \\(sa\\) と重み1の \\(bt\\) に辺ごとに対応する。
+
+#### 成立範囲
+
+ここでshortest pathと言えるのは、\\(s,t\\) が同一faceの境界上にあり、補助辺
+\\(e_0\\) によって分かれた**固定された2つのdual face \\(f_L,f_R\\)**を端点にできるからである。
+この前提を外した一般のplane graphでは、cut側の表現は \\(s,t\\) を分離するminimum separating cycleであり、
+単一の既知face対に対するshortest pathと無条件に同一視してはならない。本問はcofacialな無向の場合だけを扱い、
+directed planar flow、一般のminimum separating cycleアルゴリズム、higher-genus surfaceへの一般化は対象外とする。
+
+#### 出典と拡張の境界
+
+この補助辺によるcost-preservingなcut--path対応は、Reif (1983) Section 3, Theorem 2の
+\\((s,t)\\)-planar networkに対する定式化に基づく（[原論文PDF](https://users.cs.duke.edu/~reif/paper/stcut.pdf)、
+DOI: 10.1137/0212005）。
+同論文の定理は正のcostを仮定する。本解答で用いた非負capacityへの拡張は、0-weight edgeがあっても
+minimum cutから包含極小なものを、shortest walkからsimple pathを選べることによる。これは本文で明示した
+bond--cycleの議論から従う拡張であり、一次文献の定理文をそのまま引用した主張ではない。
 
 <span id="ex-sol-ch8-006"></span>
 ### 練習問題8.6（発展6）

--- a/src/chapter-8/index.md
+++ b/src/chapter-8/index.md
@@ -594,6 +594,7 @@ Gale-Shapley(男性の選好, 女性の選好):
 - **標準**: Adrian Bondy, U. S. R. Murty, 『Graph Theory』. グラフ理論の基本概念から定理までを整理して復習できます。
 - **ネットワーク**: Ravindra K. Ahuja, Thomas L. Magnanti, James B. Orlin, 『Network Flows』. 最短路・最大流・最小費用流を体系的に深掘りしたい読者向けです。
 - **アルゴリズム**: Jon Kleinberg, Éva Tardos, 『Algorithm Design』. グラフ問題の設計判断と実用上の典型例を追いやすい標準書です。
+- **平面双対**: John H. Reif, “Minimum s-t Cut of a Planar Undirected Network in O(n log^2 n) Time,” *SIAM Journal on Computing* 12(1), 1983, Sections 2.4 and 3（[原論文PDF](https://users.cs.duke.edu/~reif/paper/stcut.pdf)、DOI: 10.1137/0212005）. 同一face上の端点に対する補助辺とdual shortest pathの対応を確認できます。
 - **出典メモ**: 最短路では Dijkstra、フローでは Ford–Fulkerson 系の古典的結果が核になります。本章ではそれらを現代的な計算量評価と実装上の前提条件に接続しています。
 - **次の一歩**: グラフ上の性質を論理で記述して検証したい場合は第9章へ進んでください。分散ネットワークや状態遷移系の応用像を見たい場合は第12章と往復すると見通しが良くなります。
 ## 章末問題
@@ -634,9 +635,17 @@ Gale-Shapley(男性の選好, 女性の選好):
 
 ### 発展問題
 
-5. <span id="exq-ch8-005"></span>プラナーグラフの双対グラフについて：
-   (a) 双対グラフの定義と性質を述べよ
-   (b) 最短路と最小カットの双対性を説明せよ
+5. <span id="exq-ch8-005"></span>次の条件を固定する。\(G=(V,E)\) は**連結な無向plane graph**
+   （固定された平面埋め込みを持つグラフ）、各辺 \(e\) のedge capacity \(c(e)\) は非負であり、
+   異なる頂点 \(s,t\) は同一faceの境界上にある。
+   (a) 埋め込みに対するdual graph \(G^{\ast}\) を定義し、橋と平行辺が双対でどう表されるか述べよ。
+   (b) \(s,t\) が接するface内に補助辺 \(e_0=(s,t)\) を交差なく追加する。この辺が元のfaceを
+   \(f_L,f_R\) に分けるとする。拡張後のdual graphから \(e_0^{\ast}\) を削除し、元の各辺に対して
+   \(w(e^{\ast})=c(e)\) と置いたとき、minimum \(s\)-\(t\) cutの容量が \(f_L\)-\(f_R\)
+   shortest pathの重みに等しいことを、両方向の対応を示して証明せよ。この設問ではshortest path版だけを証明し、
+   一般の埋め込みで現れるminimum separating cycleとは区別すること。
+   (c) 4-cycle \(s-a-t-b-s\) を固定埋め込みし、容量を順に \(2,3,1,4\) とした例で、
+   primal cutとdual pathの値を手計算せよ。
 
 - **詳細解答**: [付録Cの対応解答](../appendices/c/#ex-sol-ch8-005)
 


### PR DESCRIPTION
## 概要

- 練習問題8.5を、fixed planar embeddingを持つ連結無向plane graph、非負capacity、cofacialな` s,t `という成立条件へ限定
- 補助辺`e0=(s,t)`でfaceを`f_L/f_R`へ分割し、`e0*`を除いたdualでminimum `s-t` cutを`f_L-f_R` shortest pathへ対応付け
- cut→path、path→cut、capacity/weight保存を証明し、一般のminimum separating cycleと区別
- 4-cycleのprimal cut / dual pathを手計算し、Reif (1983)の一次文献と非負capacityへの拡張境界を明記
- Exercise 8.5専用contract、曖昧表現のnegative test、4-cycleの実行検査、全消失の回帰検査を追加
- `src` / `docs` / index / search dataを同期

## 検証

- `python3 scripts/check_appendix_c_consistency.py`
- `python3 -m pytest -q python/tests/test_check_appendix_c_consistency.py` — 119 passed
- `.venv/bin/python -m pytest -q` — 274 passed
- `npm test`
- `npm run spellcheck` — 72 files / 0 issues
- Jekyll production build、HTML notation、generated exercise anchors
- pinned `book-formatter` `69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c`: Unicode / textlint / links / layout / structureすべてerror 0、warning 0

Closes #425
